### PR TITLE
test(no-hard-coded-timeout): fix test cases and add missing globals

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -113,7 +113,9 @@ jobs:
             });
             const botComments = comments.data.filter(
               comment => comment.user.type === 'Bot' &&
-              comment.body.includes('Coverage after merging')
+              (comment.body.includes('Coverage after merging') ||
+               comment.body.includes('Coverage Report') ||
+               comment.body.includes('lcov-reporter-action'))
             );
             for (const comment of botComments) {
               await github.rest.issues.deleteComment({

--- a/docs/rules/no-hard-coded-timeout.md
+++ b/docs/rules/no-hard-coded-timeout.md
@@ -1,0 +1,126 @@
+# no-hard-coded-timeout
+
+Disallow hard-coded timeouts in tests
+
+## Rule Details
+
+This rule helps prevent test flakiness by discouraging the use of hard-coded timeouts in test files. Hard-coded timeouts can make tests brittle and unpredictable across different environments and system conditions.
+
+The rule detects and reports:
+
+- `setTimeout()` calls with fixed delays
+- `setInterval()` usage in tests
+- Promise-based timeout patterns
+- Cypress `cy.wait()` with numeric delays
+- Common wait/delay/sleep helper functions
+
+### Examples of **incorrect** code
+
+```javascript
+// setTimeout with hard-coded delay
+setTimeout(() => {
+  expect(element).toBeVisible();
+}, 2000);
+
+// setInterval in tests
+setInterval(() => {
+  checkStatus();
+}, 1000);
+
+// Promise-based timeouts
+await new Promise((resolve) => setTimeout(resolve, 3000));
+
+// Cypress fixed waits
+cy.wait(5000);
+
+// Custom wait helpers
+await wait(2000);
+await delay(1500);
+```
+
+### Examples of **correct** code
+
+```javascript
+// Use waitFor utilities
+await waitFor(
+  () => {
+    expect(element).toBeVisible();
+  },
+  { timeout: 2000 },
+);
+
+// Use polling with waitFor
+await waitFor(() => {
+  return checkStatus();
+});
+
+// Use Cypress aliases
+cy.intercept("GET", "/api/data").as("getData");
+cy.wait("@getData");
+
+// Mock timers
+jest.setTimeout(10000);
+vi.setTimeout(10000);
+```
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+### `maxTimeout`
+
+- Type: `number`
+- Default: `1000`
+
+The maximum timeout value (in milliseconds) allowed before the rule reports an issue. Timeouts below this threshold won't be reported.
+
+```json
+{
+  "rules": {
+    "test-flakiness/no-hard-coded-timeout": ["error", { "maxTimeout": 500 }]
+  }
+}
+```
+
+### `allowInSetup`
+
+- Type: `boolean`
+- Default: `false`
+
+When set to `true`, allows hard-coded timeouts in setup and teardown hooks (`before`, `after`, `beforeEach`, `afterEach`, `beforeAll`, `afterAll`).
+
+```json
+{
+  "rules": {
+    "test-flakiness/no-hard-coded-timeout": ["error", { "allowInSetup": true }]
+  }
+}
+```
+
+## When Not To Use It
+
+This rule may not be suitable if:
+
+- Your test suite requires specific timing for integration tests
+- You're testing timeout behavior itself
+- You're working with legacy code that heavily relies on timeouts
+
+## Automatic Fixes
+
+This rule provides automatic fixes for some patterns:
+
+- `setTimeout` calls are converted to `waitFor` patterns
+- Promise-based timeouts are converted to `waitFor` utilities
+
+Note: Automatic fixes should be reviewed as they may require additional imports or setup depending on your testing framework.
+
+## Related Rules
+
+- [no-promise-wait](./no-promise-wait.md)
+- [no-cy-wait](./no-cy-wait.md)
+
+## Further Reading
+
+- [Testing Library - waitFor](https://testing-library.com/docs/dom-testing-library/api-async/#waitfor)
+- [Cypress - Network Requests](https://docs.cypress.io/guides/guides/network-requests)
+- [Jest - Timer Mocks](https://jestjs.io/docs/timer-mocks)

--- a/eslint-plugin-test-flakiness.code-workspace
+++ b/eslint-plugin-test-flakiness.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"name": "lib",
+			"path": "./lib"
+		},
+		{
+			"name": "tests",
+			"path": "./tests"
+		},
+		{
+			"name": "root",
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,6 @@
 import js from '@eslint/js';
+import testFlakiness from './lib/index.js';
+
 export default [
   js.configs.recommended,
   {
@@ -18,6 +20,13 @@ export default [
         module: 'writable',
         require: 'readonly',
         global: 'readonly',
+        // Browser/Timer globals
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        window: 'readonly',
+        document: 'readonly',
         // Jest globals
         describe: 'readonly',
         it: 'readonly',
@@ -28,13 +37,28 @@ export default [
         beforeAll: 'readonly',
         afterAll: 'readonly',
         jest: 'readonly',
+        // Testing library globals
+        screen: 'readonly',
+        // Cypress globals
+        cy: 'readonly',
       },
     },
+    plugins: {
+      'test-flakiness': testFlakiness,
+    },
     rules: {
-      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
       'no-console': 'off',
       'semi': ['error', 'always'],
       'quotes': ['error', 'single'],
+      'test-flakiness/no-hard-coded-timeout': 'error',
+    },
+  },
+  {
+    // Disable the no-hard-coded-timeout rule for its own test file
+    files: ['tests/lib/rules/no-hard-coded-timeout.test.js'],
+    rules: {
+      'test-flakiness/no-hard-coded-timeout': 'off',
     },
   },
   {

--- a/examples/no-hard-coded-timeout-violations.test.js
+++ b/examples/no-hard-coded-timeout-violations.test.js
@@ -1,0 +1,63 @@
+/* eslint-disable test-flakiness/no-hard-coded-timeout */
+/**
+ * Examples of no-hard-coded-timeout rule violations
+ * These patterns should be detected by the eslint-plugin-test-flakiness
+ */
+
+describe('Hard-coded Timeout Violations', () => {
+  // ❌ BAD: Using setTimeout with fixed delay
+  it('should wait with setTimeout', async () => {
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    expect(document.querySelector('.loaded')).toBeTruthy();
+  });
+
+  // ❌ BAD: Using setTimeout directly
+  it('should use raw setTimeout', (done) => {
+    setTimeout(() => {
+      expect(true).toBe(true);
+      done();
+    }, 3000);
+  });
+
+  // ❌ BAD: Promise-based timeout
+  it('should wait with promise timeout', async () => {
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    expect(screen.getByText('Loaded')).toBeInTheDocument();
+  });
+
+  // ❌ BAD: Using setInterval
+  it('should not use setInterval', () => {
+    const interval = setInterval(() => {
+      console.log('checking...');
+    }, 1000);
+
+    // cleanup would happen here
+    clearInterval(interval);
+  });
+
+  // ❌ BAD: Custom wait/delay functions
+  it('should avoid custom wait functions', async () => {
+    const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+    await wait(2000);
+    expect(true).toBe(true);
+  });
+
+  // ❌ BAD: Cypress fixed wait
+  it('should not use cy.wait with number', () => {
+    cy.visit('/page');
+    cy.wait(5000); // Bad: fixed delay
+    cy.get('.content').should('be.visible');
+  });
+
+  // ❌ BAD: Sleep/delay/pause patterns
+  it('should avoid sleep patterns', async () => {
+    const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+    await sleep(1500);
+
+    const delay = (ms) => new Promise(r => setTimeout(r, ms));
+    await delay(2000);
+
+    const pause = (ms) => new Promise(r => setTimeout(r, ms));
+    await pause(1000);
+  });
+});

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -5,5 +5,7 @@
 
 module.exports = {
   plugins: ['test-flakiness'],
-  rules: {}
+  rules: {
+    'test-flakiness/no-hard-coded-timeout': 'error'
+  }
 };

--- a/lib/configs/strict.js
+++ b/lib/configs/strict.js
@@ -5,5 +5,10 @@
 
 module.exports = {
   plugins: ['test-flakiness'],
-  rules: {}
+  rules: {
+    'test-flakiness/no-hard-coded-timeout': ['error', {
+      maxTimeout: 500,
+      allowInSetup: false
+    }]
+  }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ const getRules = () => {
   if (fs.existsSync(rulesPath)) {
     try {
       rules = requireIndex(rulesPath);
-    } catch (err) {
+    } catch (_err) {
       // Silently handle error and return empty rules object
       rules = {};
     }

--- a/lib/rules/no-hard-coded-timeout.js
+++ b/lib/rules/no-hard-coded-timeout.js
@@ -1,0 +1,270 @@
+/**
+ * @fileoverview Rule to disallow hard-coded timeouts in tests
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const { isTestFile, isInMockContext, getFilename } = require('../utils/helpers');
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow hard-coded timeouts in tests',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/tigredonorte/eslint-plugin-test-flakiness/blob/main/docs/rules/no-hard-coded-timeout.md'
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          maxTimeout: {
+            type: 'number',
+            default: 1000
+          },
+          allowInSetup: {
+            type: 'boolean',
+            default: false
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      avoidHardTimeout: 'Avoid hard-coded timeout of {{timeout}}ms. Use waitFor() or findBy queries instead.',
+      avoidSetInterval: 'Avoid setInterval in tests. Use polling with waitFor() instead.',
+      avoidPromiseTimeout: 'Avoid Promise-based timeouts. Use waitFor() utilities instead.',
+      avoidCypressWait: 'Avoid cy.wait() with fixed delays. Use cy.intercept() or cy.wait(@alias) instead.'
+    }
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    const maxTimeout = options.maxTimeout || 1000;
+    const allowInSetup = options.allowInSetup || false;
+
+    if (!isTestFile(getFilename(context))) {
+      return {};
+    }
+
+    function checkSetTimeout(node) {
+      // Skip if in mock context (jest.setTimeout, vi.setTimeout)
+      if (isInMockContext(node, context)) {
+        return;
+      }
+
+      // Check for setTimeout with numeric delay
+      const isSetTimeout = node.callee.name === 'setTimeout' ||
+          (node.callee.type === 'MemberExpression' &&
+           node.callee.property.name === 'setTimeout');
+
+      if (!isSetTimeout) {
+        return;
+      }
+
+      const delayArg = node.arguments[1];
+      if (!delayArg || delayArg.type !== 'Literal' ||
+          typeof delayArg.value !== 'number' ||
+          delayArg.value < maxTimeout) {
+        return;
+      }
+
+      // Skip if in setup/teardown and allowed
+      if (allowInSetup && isInSetupTeardown(node)) {
+        return;
+      }
+
+      context.report({
+        node: delayArg,
+        messageId: 'avoidHardTimeout',
+        data: { timeout: delayArg.value },
+        fix(fixer) {
+          // Suggest waitFor pattern
+          const callbackNode = node.arguments[0];
+          const callbackText = context.getSourceCode().getText(callbackNode);
+
+          // Check if callback is already a function
+          let waitForCallback;
+          if (callbackNode.type === 'FunctionExpression' ||
+              callbackNode.type === 'ArrowFunctionExpression') {
+            // Extract the body of the function
+            const bodyNode = callbackNode.body;
+            if (bodyNode.type === 'BlockStatement') {
+              // Get the inner content of the block without braces
+              const sourceCode = context.getSourceCode();
+              const bodyText = sourceCode.getText(bodyNode);
+              // Remove the outer braces and trim
+              const innerBody = bodyText.slice(1, -1).trim();
+              waitForCallback = `async () => {\n  ${innerBody}\n}`;
+            } else {
+              // Arrow function with expression body
+              const bodyText = context.getSourceCode().getText(bodyNode);
+              waitForCallback = `async () => ${bodyText}`;
+            }
+          } else {
+            // Not a function, wrap it
+            waitForCallback = `async () => {\n  ${callbackText}\n}`;
+          }
+
+          // Check if we're in an async context
+          let inAsyncContext = false;
+          let parent = node.parent;
+          while (parent) {
+            if (parent.type === 'FunctionExpression' ||
+                parent.type === 'ArrowFunctionExpression' ||
+                parent.type === 'FunctionDeclaration') {
+              inAsyncContext = parent.async === true;
+              break;
+            }
+            parent = parent.parent;
+          }
+
+          const prefix = inAsyncContext ? 'await ' : '';
+          return fixer.replaceText(
+            node,
+            `${prefix}waitFor(${waitForCallback}, { timeout: ${delayArg.value} })`
+          );
+        }
+      });
+    }
+
+    function checkSetInterval(node) {
+      const isSetInterval = node.callee.name === 'setInterval' ||
+          (node.callee.type === 'MemberExpression' &&
+           node.callee.property.name === 'setInterval');
+
+      if (!isSetInterval) {
+        return;
+      }
+
+      if (isInMockContext(node, context)) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'avoidSetInterval'
+      });
+    }
+
+    function checkPromiseTimeout(node) {
+      // Check for: new Promise(resolve => setTimeout(resolve, n))
+      if (node.callee.name !== 'Promise') {
+        return;
+      }
+
+      if (!node.arguments[0] || node.arguments[0].type !== 'ArrowFunctionExpression') {
+        return;
+      }
+
+      const body = node.arguments[0].body;
+      let setTimeoutCall = null;
+
+      // Handle both expression body and block statement body
+      if (body.type === 'CallExpression' && body.callee.name === 'setTimeout') {
+        // Direct expression: resolve => setTimeout(resolve, n)
+        setTimeoutCall = body;
+      } else if (body.type === 'BlockStatement' && body.body && body.body.length === 1) {
+        // Block with single statement: resolve => { setTimeout(resolve, n); }
+        const stmt = body.body[0];
+        if (stmt.type === 'ExpressionStatement' &&
+            stmt.expression.type === 'CallExpression' &&
+            stmt.expression.callee.name === 'setTimeout') {
+          setTimeoutCall = stmt.expression;
+        }
+      }
+
+      if (!setTimeoutCall) {
+        return;
+      }
+
+      const delayArg = setTimeoutCall.arguments[1];
+      if (!delayArg || delayArg.type !== 'Literal' || delayArg.value < maxTimeout) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'avoidPromiseTimeout',
+        fix(fixer) {
+          return fixer.replaceText(
+            node,
+            `waitFor(() => expect(true).toBe(true), { timeout: ${delayArg.value} })`
+          );
+        }
+      });
+    }
+
+    function checkCypressWait(node) {
+      // Check for cy.wait(number)
+      if (node.callee.type !== 'MemberExpression' ||
+          node.callee.object.name !== 'cy' ||
+          node.callee.property.name !== 'wait') {
+        return;
+      }
+
+      if (!node.arguments[0] ||
+          node.arguments[0].type !== 'Literal' ||
+          typeof node.arguments[0].value !== 'number') {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'avoidCypressWait'
+      });
+    }
+
+    function checkWaitHelpers(node) {
+      // Check for common wait/delay/sleep helpers
+      const functionName = node.callee.name;
+      if (!functionName || !/^(wait|delay|sleep|pause)$/i.test(functionName)) {
+        return;
+      }
+
+      const delayArg = node.arguments[0];
+      if (!delayArg || delayArg.type !== 'Literal' ||
+          typeof delayArg.value !== 'number' ||
+          delayArg.value < maxTimeout) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'avoidHardTimeout',
+        data: { timeout: delayArg.value }
+      });
+    }
+
+    function isInSetupTeardown(node) {
+      let parent = node.parent;
+      while (parent) {
+        if (parent.type === 'CallExpression' &&
+            parent.callee.type === 'Identifier') {
+          const name = parent.callee.name;
+          if (/^(before|after)(Each|All)?$/.test(name)) {
+            return true;
+          }
+        }
+        parent = parent.parent;
+      }
+      return false;
+    }
+
+    return {
+      CallExpression(node) {
+        checkSetTimeout(node);
+        checkSetInterval(node);
+        checkPromiseTimeout(node);
+        checkCypressWait(node);
+        checkWaitHelpers(node);
+      },
+      
+      NewExpression(node) {
+        checkPromiseTimeout(node);
+      }
+    };
+  }
+};

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -1,0 +1,306 @@
+/**
+ * @fileoverview Utility functions for eslint-plugin-test-flakiness
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+/**
+ * Check if a file is a test file based on naming patterns
+ * @param {string} filename - The filename to check
+ * @returns {boolean} Whether the file is a test file
+ */
+function isTestFile(filename) {
+  if (!filename) return false;
+  
+  const testPatterns = [
+    /\.(test|spec)\.(js|jsx|ts|tsx|mjs|cjs)$/,
+    /\.(test|spec)\.stories\.(js|jsx|ts|tsx)$/,
+    /\/__tests__\//,
+    /\/(test|tests|spec|specs)\//,
+    /\.(e2e|integration|cy)\.(js|jsx|ts|tsx)$/,
+    /\/cypress\//,
+    /\/playwright\//,
+    /\.steps?\.(js|jsx|ts|tsx)$/
+  ];
+  
+  return testPatterns.some(pattern => pattern.test(filename));
+}
+
+/**
+ * Check if a node is within a mock or stub context
+ * @param {Object} node - The AST node to check
+ * @param {Object} context - The ESLint context
+ * @returns {boolean} Whether the node is in a mock context
+ */
+function isInMockContext(node, context) {
+  // Check if the node itself is a mock call
+  if (node.callee) {
+    const calleeText = context.getSourceCode().getText(node.callee);
+    
+    // Common mock patterns
+    const mockPatterns = [
+      /^jest\./,
+      /^vi\./,
+      /^sinon\./,
+      /^mock/i,
+      /^stub/i,
+      /^spy/i,
+      /^fake/i,
+      /\.mock/,
+      /\.spyOn/,
+      /\.stub/,
+      /\.fake/
+    ];
+    
+    if (mockPatterns.some(pattern => pattern.test(calleeText))) {
+      return true;
+    }
+  }
+  
+  // Check parent context (look up to 5 levels)
+  let parent = node.parent;
+  let level = 0;
+  
+  while (parent && level < 5) {
+    if (parent.type === 'CallExpression') {
+      const calleeText = context.getSourceCode().getText(parent.callee);
+      
+      // Check for mock setup functions
+      if (/mock|stub|spy|fake|jest\.fn|vi\.fn|sinon\./i.test(calleeText)) {
+        return true;
+      }
+      
+      // Check for jest.mock() or vi.mock() module mocking
+      if (parent.callee.type === 'MemberExpression') {
+        const object = parent.callee.object.name;
+        const method = parent.callee.property.name;
+        if ((object === 'jest' || object === 'vi') && method === 'mock') {
+          return true;
+        }
+      }
+    }
+    
+    parent = parent.parent;
+    level++;
+  }
+  
+  return false;
+}
+
+/**
+ * Check if a node is within a specific test hook
+ * @param {Object} node - The AST node to check
+ * @param {Array<string>} hookNames - Hook names to check for
+ * @returns {boolean} Whether the node is in one of the specified hooks
+ */
+function isInHook(node, hookNames) {
+  let parent = node.parent;
+  
+  while (parent) {
+    if (parent.type === 'CallExpression' && 
+        parent.callee.type === 'Identifier' &&
+        hookNames.includes(parent.callee.name)) {
+      return true;
+    }
+    parent = parent.parent;
+  }
+  
+  return false;
+}
+
+/**
+ * Check if a node is within a describe block
+ * @param {Object} node - The AST node to check
+ * @returns {boolean} Whether the node is in a describe block
+ */
+function isInDescribe(node) {
+  let parent = node.parent;
+  
+  while (parent) {
+    if (parent.type === 'CallExpression' && 
+        parent.callee.type === 'Identifier' &&
+        (parent.callee.name === 'describe' || 
+         parent.callee.name === 'context' ||
+         parent.callee.name === 'suite')) {
+      return true;
+    }
+    parent = parent.parent;
+  }
+  
+  return false;
+}
+
+/**
+ * Check if a node is within a test case
+ * @param {Object} node - The AST node to check
+ * @returns {boolean} Whether the node is in a test case
+ */
+function isInTest(node) {
+  let parent = node.parent;
+  
+  while (parent) {
+    if (parent.type === 'CallExpression' && 
+        parent.callee.type === 'Identifier') {
+      const name = parent.callee.name;
+      if (name === 'it' || name === 'test' || name === 'specify') {
+        return true;
+      }
+    }
+    parent = parent.parent;
+  }
+  
+  return false;
+}
+
+/**
+ * Get the filename from ESLint context (compatible with v7, v8, and v9)
+ * @param {Object} context - The ESLint context
+ * @returns {string} The filename
+ */
+function getFilename(context) {
+  // ESLint 9+ uses context.filename
+  if (context.filename) return context.filename;
+  // ESLint 8 uses getPhysicalFilename() or getFilename()
+  if (context.getPhysicalFilename) return context.getPhysicalFilename();
+  // ESLint 7 uses getFilename()
+  if (context.getFilename) return context.getFilename();
+  return '';
+}
+
+/**
+ * Get the test framework being used
+ * @param {Object} context - The ESLint context
+ * @returns {string|null} The test framework name or null
+ */
+function getTestFramework(context) {
+  const filename = getFilename(context);
+  const sourceCode = context.getSourceCode();
+  const text = sourceCode.getText();
+  
+  // Check imports/requires
+  if (/from ['"]@testing-library/.test(text)) {
+    return 'testing-library';
+  }
+  if (/from ['"]@playwright/.test(text)) {
+    return 'playwright';
+  }
+  if (/from ['"]cypress/.test(text)) {
+    return 'cypress';
+  }
+  if (/from ['"]vitest/.test(text)) {
+    return 'vitest';
+  }
+  if (/from ['"]jest/.test(text)) {
+    return 'jest';
+  }
+  
+  // Check global usage
+  if (/\b(describe|it|expect)\s*\(/.test(text)) {
+    if (/\bvi\./.test(text)) return 'vitest';
+    if (/\bjest\./.test(text)) return 'jest';
+    if (/\bcy\./.test(text)) return 'cypress';
+  }
+  
+  // Check file path
+  if (/\/cypress\//i.test(filename)) return 'cypress';
+  if (/\/playwright\//i.test(filename)) return 'playwright';
+  if (/\.cy\./i.test(filename)) return 'cypress';
+  if (/\.spec\./i.test(filename)) return 'jest'; // Default assumption
+  
+  return null;
+}
+
+/**
+ * Check if an expression is a promise or async function
+ * @param {Object} node - The AST node to check
+ * @returns {boolean} Whether the node returns a promise
+ */
+function isPromise(node) {
+  if (!node) return false;
+  
+  // Async function
+  if (node.async) return true;
+  
+  // Promise constructor
+  if (node.type === 'NewExpression' && node.callee.name === 'Promise') {
+    return true;
+  }
+  
+  // Method that typically returns promises
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+  
+  if (node.callee.type === 'MemberExpression') {
+    const method = node.callee.property.name;
+    const promiseMethods = [
+      'then', 'catch', 'finally',
+      'all', 'race', 'allSettled', 'any',
+      'resolve', 'reject'
+    ];
+    if (promiseMethods.includes(method)) {
+      return true;
+    }
+  }
+  
+  // Common async method patterns
+  const calleeText = node.callee.name || '';
+  if (/^(fetch|axios|request|get|post|put|delete|patch)/i.test(calleeText)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get the indentation string for a node
+ * @param {Object} node - The AST node
+ * @param {Object} context - The ESLint context
+ * @returns {string} The indentation string
+ */
+function getIndentation(node, context) {
+  const sourceCode = context.getSourceCode();
+  const token = sourceCode.getFirstToken(node);
+  if (!token) {
+    return '';
+  }
+
+  const line = sourceCode.lines[token.loc.start.line - 1];
+  if (!line) {
+    return '';
+  }
+
+  const match = line.match(/^(\s*)/);
+  return match ? match[1] : '';
+}
+
+/**
+ * Check if a string is likely a URL
+ * @param {string} str - The string to check
+ * @returns {boolean} Whether the string looks like a URL
+ */
+function isUrl(str) {
+  return /^(https?:\/\/|wss?:\/\/|\/\/)/.test(str);
+}
+
+/**
+ * Check if a string is a data URL
+ * @param {string} str - The string to check
+ * @returns {boolean} Whether the string is a data URL
+ */
+function isDataUrl(str) {
+  return /^(data:|blob:|file:)/.test(str);
+}
+
+module.exports = {
+  isTestFile,
+  isInMockContext,
+  isInHook,
+  isInDescribe,
+  isInTest,
+  getTestFramework,
+  isPromise,
+  getIndentation,
+  isUrl,
+  isDataUrl,
+  getFilename
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint": ">=7.0.0"
   },
   "dependencies": {
+    "cypress": "^15.2.0",
     "requireindex": "^1.2.0"
   },
   "devDependencies": {
@@ -59,7 +60,7 @@
     "commitizen": "^4.3.1",
     "conventional-changelog-conventionalcommits": "^7.0.2",
     "cz-conventional-changelog": "^3.3.0",
-    "eslint": "^8.50.0",
+    "eslint": "^9.36.0",
     "globals": "^16.4.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      cypress:
+        specifier: ^15.2.0
+        version: 15.2.0
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -54,8 +57,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(@types/node@20.19.14)(typescript@5.9.2)
       eslint:
-        specifier: ^8.50.0
-        version: 8.57.1
+        specifier: ^9.36.0
+        version: 9.36.0(jiti@2.5.1)
       globals:
         specifier: ^16.4.0
         version: 16.4.0
@@ -473,6 +476,19 @@ packages:
       }
     engines: { node: ">=v18" }
 
+  "@cypress/request@3.0.9":
+    resolution:
+      {
+        integrity: sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==,
+      }
+    engines: { node: ">= 6" }
+
+  "@cypress/xvfb@1.2.4":
+    resolution:
+      {
+        integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==,
+      }
+
   "@eslint-community/eslint-utils@4.9.0":
     resolution:
       {
@@ -489,19 +505,33 @@ packages:
       }
     engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
-  "@eslint/eslintrc@2.1.4":
+  "@eslint/config-array@0.21.0":
     resolution:
       {
-        integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==,
+        integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==,
       }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  "@eslint/js@8.57.1":
+  "@eslint/config-helpers@0.3.1":
     resolution:
       {
-        integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==,
+        integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==,
       }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/core@0.15.2":
+    resolution:
+      {
+        integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/eslintrc@3.3.1":
+    resolution:
+      {
+        integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   "@eslint/js@9.35.0":
     resolution:
@@ -510,13 +540,40 @@ packages:
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  "@humanwhocodes/config-array@0.13.0":
+  "@eslint/js@9.36.0":
     resolution:
       {
-        integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==,
+        integrity: sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==,
       }
-    engines: { node: ">=10.10.0" }
-    deprecated: Use @eslint/config-array instead
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/object-schema@2.1.6":
+    resolution:
+      {
+        integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/plugin-kit@0.3.5":
+    resolution:
+      {
+        integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@humanfs/core@0.19.1":
+    resolution:
+      {
+        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+      }
+    engines: { node: ">=18.18.0" }
+
+  "@humanfs/node@0.16.7":
+    resolution:
+      {
+        integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
+      }
+    engines: { node: ">=18.18.0" }
 
   "@humanwhocodes/module-importer@1.0.1":
     resolution:
@@ -525,12 +582,12 @@ packages:
       }
     engines: { node: ">=12.22" }
 
-  "@humanwhocodes/object-schema@2.0.3":
+  "@humanwhocodes/retry@0.4.3":
     resolution:
       {
-        integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==,
+        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
       }
-    deprecated: Use @eslint/object-schema instead
+    engines: { node: ">=18.18" }
 
   "@istanbuljs/load-nyc-config@1.1.0":
     resolution:
@@ -684,27 +741,6 @@ packages:
       {
         integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
       }
-
-  "@nodelib/fs.scandir@2.1.5":
-    resolution:
-      {
-        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
-      }
-    engines: { node: ">= 8" }
-
-  "@nodelib/fs.stat@2.0.5":
-    resolution:
-      {
-        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
-      }
-    engines: { node: ">= 8" }
-
-  "@nodelib/fs.walk@1.2.8":
-    resolution:
-      {
-        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
-      }
-    engines: { node: ">= 8" }
 
   "@octokit/auth-token@6.0.0":
     resolution:
@@ -998,6 +1034,18 @@ packages:
         integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==,
       }
 
+  "@types/sinonjs__fake-timers@8.1.1":
+    resolution:
+      {
+        integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==,
+      }
+
+  "@types/sizzle@2.3.10":
+    resolution:
+      {
+        integrity: sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==,
+      }
+
   "@types/stack-utils@2.0.3":
     resolution:
       {
@@ -1016,10 +1064,10 @@ packages:
         integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==,
       }
 
-  "@ungap/structured-clone@1.3.0":
+  "@types/yauzl@2.10.3":
     resolution:
       {
-        integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
+        integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==,
       }
 
   JSONStream@1.3.5:
@@ -1077,6 +1125,13 @@ packages:
       {
         integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==,
       }
+
+  ansi-colors@4.1.3:
+    resolution:
+      {
+        integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==,
+      }
+    engines: { node: ">=6" }
 
   ansi-escapes@4.3.2:
     resolution:
@@ -1147,6 +1202,12 @@ packages:
       }
     engines: { node: ">= 8" }
 
+  arch@2.2.0:
+    resolution:
+      {
+        integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==,
+      }
+
   argparse@1.0.10:
     resolution:
       {
@@ -1171,12 +1232,50 @@ packages:
         integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==,
       }
 
+  asn1@0.2.6:
+    resolution:
+      {
+        integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==,
+      }
+
+  assert-plus@1.0.0:
+    resolution:
+      {
+        integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==,
+      }
+    engines: { node: ">=0.8" }
+
+  astral-regex@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
+      }
+    engines: { node: ">=8" }
+
+  asynckit@0.4.0:
+    resolution:
+      {
+        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
+      }
+
   at-least-node@1.0.0:
     resolution:
       {
         integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==,
       }
     engines: { node: ">= 4.0.0" }
+
+  aws-sign2@0.7.0:
+    resolution:
+      {
+        integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==,
+      }
+
+  aws4@1.13.2:
+    resolution:
+      {
+        integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==,
+      }
 
   babel-jest@29.7.0:
     resolution:
@@ -1237,6 +1336,12 @@ packages:
       }
     hasBin: true
 
+  bcrypt-pbkdf@1.0.2:
+    resolution:
+      {
+        integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==,
+      }
+
   before-after-hook@4.0.0:
     resolution:
       {
@@ -1247,6 +1352,18 @@ packages:
     resolution:
       {
         integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
+      }
+
+  blob-util@2.0.2:
+    resolution:
+      {
+        integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==,
+      }
+
+  bluebird@3.7.2:
+    resolution:
+      {
+        integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==,
       }
 
   bottleneck@2.19.5:
@@ -1282,6 +1399,12 @@ packages:
         integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==,
       }
 
+  buffer-crc32@0.2.13:
+    resolution:
+      {
+        integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
+      }
+
   buffer-from@1.1.2:
     resolution:
       {
@@ -1300,6 +1423,20 @@ packages:
         integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==,
       }
     engines: { node: ">=6" }
+
+  call-bind-apply-helpers@1.0.2:
+    resolution:
+      {
+        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  call-bound@1.0.4:
+    resolution:
+      {
+        integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
+      }
+    engines: { node: ">= 0.4" }
 
   callsites@3.1.0:
     resolution:
@@ -1326,6 +1463,12 @@ packages:
     resolution:
       {
         integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==,
+      }
+
+  caseless@0.12.0:
+    resolution:
+      {
+        integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==,
       }
 
   chalk@2.4.2:
@@ -1362,10 +1505,24 @@ packages:
         integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==,
       }
 
+  check-more-types@2.24.0:
+    resolution:
+      {
+        integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==,
+      }
+    engines: { node: ">= 0.8.0" }
+
   ci-info@3.9.0:
     resolution:
       {
         integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==,
+      }
+    engines: { node: ">=8" }
+
+  ci-info@4.3.0:
+    resolution:
+      {
+        integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==,
       }
     engines: { node: ">=8" }
 
@@ -1418,12 +1575,26 @@ packages:
       }
     engines: { node: ">=6" }
 
+  cli-table3@0.6.1:
+    resolution:
+      {
+        integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==,
+      }
+    engines: { node: 10.* || >= 12.* }
+
   cli-table3@0.6.5:
     resolution:
       {
         integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==,
       }
     engines: { node: 10.* || >= 12.* }
+
+  cli-truncate@2.1.0:
+    resolution:
+      {
+        integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==,
+      }
+    engines: { node: ">=8" }
 
   cli-truncate@4.0.0:
     resolution:
@@ -1503,12 +1674,33 @@ packages:
         integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
       }
 
+  colors@1.4.0:
+    resolution:
+      {
+        integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==,
+      }
+    engines: { node: ">=0.1.90" }
+
+  combined-stream@1.0.8:
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
+      }
+    engines: { node: ">= 0.8" }
+
   commander@13.1.0:
     resolution:
       {
         integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==,
       }
     engines: { node: ">=18" }
+
+  commander@6.2.1:
+    resolution:
+      {
+        integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==,
+      }
+    engines: { node: ">= 6" }
 
   commitizen@4.3.1:
     resolution:
@@ -1517,6 +1709,13 @@ packages:
       }
     engines: { node: ">= 12" }
     hasBin: true
+
+  common-tags@1.8.2:
+    resolution:
+      {
+        integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==,
+      }
+    engines: { node: ">=4.0.0" }
 
   compare-func@2.0.0:
     resolution:
@@ -1607,6 +1806,12 @@ packages:
         integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
 
+  core-util-is@1.0.2:
+    resolution:
+      {
+        integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==,
+      }
+
   core-util-is@1.0.3:
     resolution:
       {
@@ -1658,6 +1863,14 @@ packages:
       }
     engines: { node: ">=12" }
 
+  cypress@15.2.0:
+    resolution:
+      {
+        integrity: sha512-J4ehSzOSb58SkXyldCe9y/oZ8ep8Bl6+q9kDUjnkqNqc2ZKzDq5KSbhIc2lHFAFR5Jtj10oNqr9JRAZbr8DA8A==,
+      }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    hasBin: true
+
   cz-conventional-changelog@3.3.0:
     resolution:
       {
@@ -1671,6 +1884,30 @@ packages:
         integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==,
       }
     engines: { node: ">=12" }
+
+  dashdash@1.14.1:
+    resolution:
+      {
+        integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==,
+      }
+    engines: { node: ">=0.10" }
+
+  dayjs@1.11.18:
+    resolution:
+      {
+        integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==,
+      }
+
+  debug@3.2.7:
+    resolution:
+      {
+        integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
+      }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.1:
     resolution:
@@ -1727,6 +1964,13 @@ packages:
         integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==,
       }
 
+  delayed-stream@1.0.0:
+    resolution:
+      {
+        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
+      }
+    engines: { node: ">=0.4.0" }
+
   detect-file@1.0.0:
     resolution:
       {
@@ -1762,13 +2006,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  doctrine@3.0.0:
-    resolution:
-      {
-        integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==,
-      }
-    engines: { node: ">=6.0.0" }
-
   dot-prop@5.3.0:
     resolution:
       {
@@ -1776,10 +2013,23 @@ packages:
       }
     engines: { node: ">=8" }
 
+  dunder-proto@1.0.1:
+    resolution:
+      {
+        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+      }
+    engines: { node: ">= 0.4" }
+
   duplexer2@0.1.4:
     resolution:
       {
         integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==,
+      }
+
+  ecc-jsbn@0.1.2:
+    resolution:
+      {
+        integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==,
       }
 
   electron-to-chromium@1.5.218:
@@ -1813,6 +2063,19 @@ packages:
         integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==,
       }
 
+  end-of-stream@1.4.5:
+    resolution:
+      {
+        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
+      }
+
+  enquirer@2.4.1:
+    resolution:
+      {
+        integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==,
+      }
+    engines: { node: ">=8.6" }
+
   env-ci@11.2.0:
     resolution:
       {
@@ -1839,6 +2102,34 @@ packages:
       {
         integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==,
       }
+
+  es-define-property@1.0.1:
+    resolution:
+      {
+        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+      }
+    engines: { node: ">= 0.4" }
+
+  es-errors@1.3.0:
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  es-object-atoms@1.1.1:
+    resolution:
+      {
+        integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  es-set-tostringtag@2.1.0:
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: ">= 0.4" }
 
   escalade@3.2.0:
     resolution:
@@ -1875,12 +2166,12 @@ packages:
       }
     engines: { node: ">=12" }
 
-  eslint-scope@7.2.2:
+  eslint-scope@8.4.0:
     resolution:
       {
-        integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==,
+        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
       }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-visitor-keys@3.4.3:
     resolution:
@@ -1889,21 +2180,32 @@ packages:
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
-  eslint@8.57.1:
+  eslint-visitor-keys@4.2.1:
     resolution:
       {
-        integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==,
+        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
       }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  espree@9.6.1:
+  eslint@9.36.0:
     resolution:
       {
-        integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==,
+        integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==,
       }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    hasBin: true
+    peerDependencies:
+      jiti: "*"
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution:
+      {
+        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   esprima@4.0.1:
     resolution:
@@ -1941,11 +2243,24 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  eventemitter2@6.4.7:
+    resolution:
+      {
+        integrity: sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==,
+      }
+
   eventemitter3@5.0.1:
     resolution:
       {
         integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
       }
+
+  execa@4.1.0:
+    resolution:
+      {
+        integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==,
+      }
+    engines: { node: ">=10" }
 
   execa@5.1.1:
     resolution:
@@ -1968,6 +2283,13 @@ packages:
       }
     engines: { node: ^18.19.0 || >=20.5.0 }
 
+  executable@4.1.1:
+    resolution:
+      {
+        integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==,
+      }
+    engines: { node: ">=4" }
+
   exit@0.1.2:
     resolution:
       {
@@ -1989,12 +2311,33 @@ packages:
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
 
+  extend@3.0.2:
+    resolution:
+      {
+        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
+      }
+
   external-editor@3.1.0:
     resolution:
       {
         integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==,
       }
     engines: { node: ">=4" }
+
+  extract-zip@2.0.1:
+    resolution:
+      {
+        integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==,
+      }
+    engines: { node: ">= 10.17.0" }
+    hasBin: true
+
+  extsprintf@1.3.0:
+    resolution:
+      {
+        integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==,
+      }
+    engines: { "0": node >=0.6.0 }
 
   fast-content-type-parse@3.0.0:
     resolution:
@@ -2026,16 +2369,16 @@ packages:
         integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
       }
 
-  fastq@1.19.1:
-    resolution:
-      {
-        integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==,
-      }
-
   fb-watchman@2.0.2:
     resolution:
       {
         integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==,
+      }
+
+  fd-slicer@1.1.0:
+    resolution:
+      {
+        integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==,
       }
 
   fdir@6.5.0:
@@ -2071,12 +2414,12 @@ packages:
       }
     engines: { node: ">=18" }
 
-  file-entry-cache@6.0.1:
+  file-entry-cache@8.0.0:
     resolution:
       {
-        integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==,
+        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
       }
-    engines: { node: ^10.12.0 || >=12.0.0 }
+    engines: { node: ">=16.0.0" }
 
   fill-range@7.1.1:
     resolution:
@@ -2146,18 +2489,31 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  flat-cache@3.2.0:
+  flat-cache@4.0.1:
     resolution:
       {
-        integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==,
+        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
       }
-    engines: { node: ^10.12.0 || >=12.0.0 }
+    engines: { node: ">=16" }
 
   flatted@3.3.3:
     resolution:
       {
         integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==,
       }
+
+  forever-agent@0.6.1:
+    resolution:
+      {
+        integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==,
+      }
+
+  form-data@4.0.4:
+    resolution:
+      {
+        integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==,
+      }
+    engines: { node: ">= 6" }
 
   from2@2.3.0:
     resolution:
@@ -2227,12 +2583,33 @@ packages:
       }
     engines: { node: ">=18" }
 
+  get-intrinsic@1.3.0:
+    resolution:
+      {
+        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+      }
+    engines: { node: ">= 0.4" }
+
   get-package-type@0.1.0:
     resolution:
       {
         integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==,
       }
     engines: { node: ">=8.0.0" }
+
+  get-proto@1.0.1:
+    resolution:
+      {
+        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: ">= 0.4" }
+
+  get-stream@5.2.0:
+    resolution:
+      {
+        integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==,
+      }
+    engines: { node: ">=8" }
 
   get-stream@6.0.1:
     resolution:
@@ -2261,6 +2638,12 @@ packages:
         integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==,
       }
     engines: { node: ">=18" }
+
+  getpass@0.1.7:
+    resolution:
+      {
+        integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==,
+      }
 
   git-log-parser@1.2.1:
     resolution:
@@ -2297,6 +2680,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  global-dirs@3.0.1:
+    resolution:
+      {
+        integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==,
+      }
+    engines: { node: ">=10" }
+
   global-modules@1.0.0:
     resolution:
       {
@@ -2311,12 +2701,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  globals@13.24.0:
+  globals@14.0.0:
     resolution:
       {
-        integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==,
+        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
       }
-    engines: { node: ">=8" }
+    engines: { node: ">=18" }
 
   globals@16.4.0:
     resolution:
@@ -2324,6 +2714,13 @@ packages:
         integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==,
       }
     engines: { node: ">=18" }
+
+  gopd@1.2.0:
+    resolution:
+      {
+        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+      }
+    engines: { node: ">= 0.4" }
 
   graceful-fs@4.2.10:
     resolution:
@@ -2335,12 +2732,6 @@ packages:
     resolution:
       {
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
-
-  graphemer@1.4.0:
-    resolution:
-      {
-        integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==,
       }
 
   handlebars@4.7.8:
@@ -2362,6 +2753,27 @@ packages:
     resolution:
       {
         integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: ">=8" }
+
+  has-symbols@1.1.0:
+    resolution:
+      {
+        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  has-tostringtag@1.0.2:
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  hasha@5.2.2:
+    resolution:
+      {
+        integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==,
       }
     engines: { node: ">=8" }
 
@@ -2419,12 +2831,26 @@ packages:
       }
     engines: { node: ">= 14" }
 
+  http-signature@1.4.0:
+    resolution:
+      {
+        integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==,
+      }
+    engines: { node: ">=0.10" }
+
   https-proxy-agent@7.0.6:
     resolution:
       {
         integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
       }
     engines: { node: ">= 14" }
+
+  human-signals@1.1.1:
+    resolution:
+      {
+        integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==,
+      }
+    engines: { node: ">=8.12.0" }
 
   human-signals@2.1.0:
     resolution:
@@ -2550,6 +2976,13 @@ packages:
         integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
       }
 
+  ini@2.0.0:
+    resolution:
+      {
+        integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==,
+      }
+    engines: { node: ">=10" }
+
   ini@4.1.1:
     resolution:
       {
@@ -2626,6 +3059,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  is-installed-globally@0.4.0:
+    resolution:
+      {
+        integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==,
+      }
+    engines: { node: ">=10" }
+
   is-interactive@1.0.0:
     resolution:
       {
@@ -2689,6 +3129,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  is-typedarray@1.0.0:
+    resolution:
+      {
+        integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==,
+      }
+
   is-unicode-supported@0.1.0:
     resolution:
       {
@@ -2726,6 +3172,12 @@ packages:
     resolution:
       {
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
+
+  isstream@0.1.2:
+    resolution:
+      {
+        integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==,
       }
 
   issue-parser@7.0.1:
@@ -3018,6 +3470,12 @@ packages:
       }
     hasBin: true
 
+  jsbn@0.1.1:
+    resolution:
+      {
+        integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==,
+      }
+
   jsesc@3.1.0:
     resolution:
       {
@@ -3056,10 +3514,22 @@ packages:
         integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
       }
 
+  json-schema@0.4.0:
+    resolution:
+      {
+        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==,
+      }
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution:
       {
         integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+      }
+
+  json-stringify-safe@5.0.1:
+    resolution:
+      {
+        integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==,
       }
 
   json5@2.2.3:
@@ -3083,6 +3553,13 @@ packages:
       }
     engines: { "0": node >= 0.2.0 }
 
+  jsprim@2.0.2:
+    resolution:
+      {
+        integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==,
+      }
+    engines: { "0": node >=0.6.0 }
+
   keyv@4.5.4:
     resolution:
       {
@@ -3095,6 +3572,13 @@ packages:
         integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
       }
     engines: { node: ">=6" }
+
+  lazy-ass@1.6.0:
+    resolution:
+      {
+        integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==,
+      }
+    engines: { node: "> 0.8" }
 
   leven@3.1.0:
     resolution:
@@ -3130,6 +3614,18 @@ packages:
       }
     engines: { node: ">=18.12.0" }
     hasBin: true
+
+  listr2@3.14.0:
+    resolution:
+      {
+        integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==,
+      }
+    engines: { node: ">=10.0.0" }
+    peerDependencies:
+      enquirer: ">= 2.3.0 < 3"
+    peerDependenciesMeta:
+      enquirer:
+        optional: true
 
   listr2@8.3.3:
     resolution:
@@ -3233,6 +3729,12 @@ packages:
         integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==,
       }
 
+  lodash.once@4.1.1:
+    resolution:
+      {
+        integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
+      }
+
   lodash.snakecase@4.1.1:
     resolution:
       {
@@ -3273,6 +3775,13 @@ packages:
     resolution:
       {
         integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==,
+      }
+    engines: { node: ">=10" }
+
+  log-update@4.0.0:
+    resolution:
+      {
+        integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==,
       }
     engines: { node: ">=10" }
 
@@ -3332,6 +3841,13 @@ packages:
     engines: { node: ">= 18" }
     hasBin: true
 
+  math-intrinsics@1.1.0:
+    resolution:
+      {
+        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+      }
+    engines: { node: ">= 0.4" }
+
   meow@12.1.1:
     resolution:
       {
@@ -3364,6 +3880,20 @@ packages:
         integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
       }
     engines: { node: ">=8.6" }
+
+  mime-db@1.52.0:
+    resolution:
+      {
+        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+      }
+    engines: { node: ">= 0.6" }
+
+  mime-types@2.1.35:
+    resolution:
+      {
+        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+      }
+    engines: { node: ">= 0.6" }
 
   mime@4.1.0:
     resolution:
@@ -3593,6 +4123,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  object-inspect@1.13.4:
+    resolution:
+      {
+        integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
+      }
+    engines: { node: ">= 0.4" }
+
   once@1.4.0:
     resolution:
       {
@@ -3640,6 +4177,12 @@ packages:
         integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==,
       }
     engines: { node: ">=0.10.0" }
+
+  ospath@1.2.2:
+    resolution:
+      {
+        integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==,
+      }
 
   p-each-series@3.0.0:
     resolution:
@@ -3717,6 +4260,13 @@ packages:
         integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==,
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+  p-map@4.0.0:
+    resolution:
+      {
+        integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==,
+      }
+    engines: { node: ">=10" }
 
   p-map@7.0.3:
     resolution:
@@ -3868,6 +4418,18 @@ packages:
       }
     engines: { node: ">=8" }
 
+  pend@1.2.0:
+    resolution:
+      {
+        integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==,
+      }
+
+  performance-now@2.1.0:
+    resolution:
+      {
+        integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==,
+      }
+
   picocolors@1.1.1:
     resolution:
       {
@@ -3895,6 +4457,13 @@ packages:
       }
     engines: { node: ">=0.10" }
     hasBin: true
+
+  pify@2.3.0:
+    resolution:
+      {
+        integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==,
+      }
+    engines: { node: ">=0.10.0" }
 
   pify@3.0.0:
     resolution:
@@ -3939,6 +4508,13 @@ packages:
     engines: { node: ">=14" }
     hasBin: true
 
+  pretty-bytes@5.6.0:
+    resolution:
+      {
+        integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==,
+      }
+    engines: { node: ">=6" }
+
   pretty-format@29.7.0:
     resolution:
       {
@@ -3959,6 +4535,13 @@ packages:
         integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
       }
 
+  process@0.11.10:
+    resolution:
+      {
+        integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==,
+      }
+    engines: { node: ">= 0.6.0" }
+
   prompts@2.4.2:
     resolution:
       {
@@ -3970,6 +4553,18 @@ packages:
     resolution:
       {
         integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==,
+      }
+
+  proxy-from-env@1.0.0:
+    resolution:
+      {
+        integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==,
+      }
+
+  pump@3.0.3:
+    resolution:
+      {
+        integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==,
       }
 
   punycode@2.3.1:
@@ -3985,11 +4580,12 @@ packages:
         integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==,
       }
 
-  queue-microtask@1.2.3:
+  qs@6.14.0:
     resolution:
       {
-        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+        integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==,
       }
+    engines: { node: ">=0.6" }
 
   rc@1.2.8:
     resolution:
@@ -4037,6 +4633,12 @@ packages:
         integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==,
       }
     engines: { node: ">=14" }
+
+  request-progress@3.0.0:
+    resolution:
+      {
+        integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==,
+      }
 
   require-directory@2.1.1:
     resolution:
@@ -4116,26 +4718,11 @@ packages:
       }
     engines: { node: ">=18" }
 
-  reusify@1.1.0:
-    resolution:
-      {
-        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
-      }
-    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
-
   rfdc@1.4.1:
     resolution:
       {
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
-
-  rimraf@3.0.2:
-    resolution:
-      {
-        integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==,
-      }
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   run-async@2.4.1:
     resolution:
@@ -4143,12 +4730,6 @@ packages:
         integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==,
       }
     engines: { node: ">=0.12.0" }
-
-  run-parallel@1.2.0:
-    resolution:
-      {
-        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
-      }
 
   rxjs@7.8.2:
     resolution:
@@ -4225,6 +4806,34 @@ packages:
       }
     engines: { node: ">=8" }
 
+  side-channel-list@1.0.0:
+    resolution:
+      {
+        integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  side-channel-map@1.0.1:
+    resolution:
+      {
+        integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  side-channel-weakmap@1.0.2:
+    resolution:
+      {
+        integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
+      }
+    engines: { node: ">= 0.4" }
+
+  side-channel@1.1.0:
+    resolution:
+      {
+        integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
+      }
+    engines: { node: ">= 0.4" }
+
   signal-exit@3.0.7:
     resolution:
       {
@@ -4264,6 +4873,20 @@ packages:
         integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
       }
     engines: { node: ">=8" }
+
+  slice-ansi@3.0.0:
+    resolution:
+      {
+        integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==,
+      }
+    engines: { node: ">=8" }
+
+  slice-ansi@4.0.0:
+    resolution:
+      {
+        integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
+      }
+    engines: { node: ">=10" }
 
   slice-ansi@5.0.0:
     resolution:
@@ -4340,6 +4963,14 @@ packages:
       {
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
       }
+
+  sshpk@1.18.0:
+    resolution:
+      {
+        integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==,
+      }
+    engines: { node: ">=0.10.0" }
+    hasBin: true
 
   stack-utils@2.0.6:
     resolution:
@@ -4499,6 +5130,15 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  systeminformation@5.27.7:
+    resolution:
+      {
+        integrity: sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==,
+      }
+    engines: { node: ">=8.0.0" }
+    os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
+    hasBin: true
+
   temp-dir@3.0.0:
     resolution:
       {
@@ -4527,12 +5167,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  text-table@0.2.0:
-    resolution:
-      {
-        integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==,
-      }
-
   thenify-all@1.6.0:
     resolution:
       {
@@ -4544,6 +5178,12 @@ packages:
     resolution:
       {
         integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
+      }
+
+  throttleit@1.0.1:
+    resolution:
+      {
+        integrity: sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==,
       }
 
   through2@2.0.5:
@@ -4578,12 +5218,32 @@ packages:
       }
     engines: { node: ">=12.0.0" }
 
+  tldts-core@6.1.86:
+    resolution:
+      {
+        integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==,
+      }
+
+  tldts@6.1.86:
+    resolution:
+      {
+        integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==,
+      }
+    hasBin: true
+
   tmp@0.0.33:
     resolution:
       {
         integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==,
       }
     engines: { node: ">=0.6.0" }
+
+  tmp@0.2.5:
+    resolution:
+      {
+        integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==,
+      }
+    engines: { node: ">=14.14" }
 
   tmpl@1.0.5:
     resolution:
@@ -4598,6 +5258,13 @@ packages:
       }
     engines: { node: ">=8.0" }
 
+  tough-cookie@5.1.2:
+    resolution:
+      {
+        integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==,
+      }
+    engines: { node: ">=16" }
+
   traverse@0.6.8:
     resolution:
       {
@@ -4605,10 +5272,29 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  tree-kill@1.2.2:
+    resolution:
+      {
+        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+      }
+    hasBin: true
+
   tslib@2.8.1:
     resolution:
       {
         integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
+
+  tunnel-agent@0.6.0:
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
+
+  tweetnacl@0.14.5:
+    resolution:
+      {
+        integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==,
       }
 
   type-check@0.4.0:
@@ -4625,19 +5311,19 @@ packages:
       }
     engines: { node: ">=4" }
 
-  type-fest@0.20.2:
-    resolution:
-      {
-        integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==,
-      }
-    engines: { node: ">=10" }
-
   type-fest@0.21.3:
     resolution:
       {
         integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==,
       }
     engines: { node: ">=10" }
+
+  type-fest@0.8.1:
+    resolution:
+      {
+        integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==,
+      }
+    engines: { node: ">=8" }
 
   type-fest@1.4.0:
     resolution:
@@ -4723,6 +5409,13 @@ packages:
       }
     engines: { node: ">= 10.0.0" }
 
+  untildify@4.0.0:
+    resolution:
+      {
+        integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==,
+      }
+    engines: { node: ">=8" }
+
   update-browserslist-db@1.1.3:
     resolution:
       {
@@ -4751,6 +5444,13 @@ packages:
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
 
+  uuid@8.3.2:
+    resolution:
+      {
+        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
+      }
+    hasBin: true
+
   v8-to-istanbul@9.3.0:
     resolution:
       {
@@ -4763,6 +5463,13 @@ packages:
       {
         integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==,
       }
+
+  verror@1.10.0:
+    resolution:
+      {
+        integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==,
+      }
+    engines: { "0": node >=0.6.0 }
 
   walker@1.0.8:
     resolution:
@@ -4803,6 +5510,13 @@ packages:
       {
         integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==,
       }
+
+  wrap-ansi@6.2.0:
+    resolution:
+      {
+        integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==,
+      }
+    engines: { node: ">=8" }
 
   wrap-ansi@7.0.0:
     resolution:
@@ -4887,6 +5601,12 @@ packages:
       }
     engines: { node: ">=12" }
 
+  yauzl@2.10.0:
+    resolution:
+      {
+        integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==,
+      }
+
   yocto-queue@0.1.0:
     resolution:
       {
@@ -4930,7 +5650,7 @@ snapshots:
       "@babel/types": 7.28.4
       "@jridgewell/remapping": 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5087,7 +5807,7 @@ snapshots:
       "@babel/parser": 7.28.4
       "@babel/template": 7.27.2
       "@babel/types": 7.28.4
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5211,19 +5931,61 @@ snapshots:
       "@types/conventional-commits-parser": 5.0.1
       chalk: 5.6.2
 
-  "@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)":
+  "@cypress/request@3.0.9":
     dependencies:
-      eslint: 8.57.1
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 4.0.4
+      http-signature: 1.4.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      performance-now: 2.1.0
+      qs: 6.14.0
+      safe-buffer: 5.2.1
+      tough-cookie: 5.1.2
+      tunnel-agent: 0.6.0
+      uuid: 8.3.2
+
+  "@cypress/xvfb@1.2.4(supports-color@8.1.1)":
+    dependencies:
+      debug: 3.2.7(supports-color@8.1.1)
+      lodash.once: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@eslint-community/eslint-utils@4.9.0(eslint@9.36.0(jiti@2.5.1))":
+    dependencies:
+      eslint: 9.36.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
   "@eslint-community/regexpp@4.12.1": {}
 
-  "@eslint/eslintrc@2.1.4":
+  "@eslint/config-array@0.21.0":
+    dependencies:
+      "@eslint/object-schema": 2.1.6
+      debug: 4.4.1(supports-color@8.1.1)
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  "@eslint/config-helpers@0.3.1": {}
+
+  "@eslint/core@0.15.2":
+    dependencies:
+      "@types/json-schema": 7.0.15
+
+  "@eslint/eslintrc@3.3.1":
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
-      espree: 9.6.1
-      globals: 13.24.0
+      debug: 4.4.1(supports-color@8.1.1)
+      espree: 10.4.0
+      globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.0
@@ -5232,21 +5994,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@eslint/js@8.57.1": {}
-
   "@eslint/js@9.35.0": {}
 
-  "@humanwhocodes/config-array@0.13.0":
+  "@eslint/js@9.36.0": {}
+
+  "@eslint/object-schema@2.1.6": {}
+
+  "@eslint/plugin-kit@0.3.5":
     dependencies:
-      "@humanwhocodes/object-schema": 2.0.3
-      debug: 4.4.1
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
+      "@eslint/core": 0.15.2
+      levn: 0.4.1
+
+  "@humanfs/core@0.19.1": {}
+
+  "@humanfs/node@0.16.7":
+    dependencies:
+      "@humanfs/core": 0.19.1
+      "@humanwhocodes/retry": 0.4.3
 
   "@humanwhocodes/module-importer@1.0.1": {}
 
-  "@humanwhocodes/object-schema@2.0.3": {}
+  "@humanwhocodes/retry@0.4.3": {}
 
   "@istanbuljs/load-nyc-config@1.1.0":
     dependencies:
@@ -5439,18 +6207,6 @@ snapshots:
       "@jridgewell/resolve-uri": 3.1.2
       "@jridgewell/sourcemap-codec": 1.5.5
 
-  "@nodelib/fs.scandir@2.1.5":
-    dependencies:
-      "@nodelib/fs.stat": 2.0.5
-      run-parallel: 1.2.0
-
-  "@nodelib/fs.stat@2.0.5": {}
-
-  "@nodelib/fs.walk@1.2.8":
-    dependencies:
-      "@nodelib/fs.scandir": 2.1.5
-      fastq: 1.19.1
-
   "@octokit/auth-token@6.0.0": {}
 
   "@octokit/core@7.0.3":
@@ -5538,7 +6294,7 @@ snapshots:
       conventional-changelog-writer: 8.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       import-from-esm: 2.0.0
       lodash-es: 4.17.21
       micromatch: 4.0.8
@@ -5554,7 +6310,7 @@ snapshots:
     dependencies:
       "@semantic-release/error": 3.0.0
       aggregate-error: 3.1.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       dir-glob: 3.0.1
       execa: 5.1.1
       lodash: 4.17.21
@@ -5572,7 +6328,7 @@ snapshots:
       "@octokit/plugin-throttling": 11.0.1(@octokit/core@7.0.3)
       "@semantic-release/error": 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       dir-glob: 3.0.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -5609,7 +6365,7 @@ snapshots:
       conventional-changelog-writer: 8.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       get-stream: 7.0.1
       import-from-esm: 2.0.0
       into-stream: 7.0.0
@@ -5687,6 +6443,10 @@ snapshots:
 
   "@types/normalize-package-data@2.4.4": {}
 
+  "@types/sinonjs__fake-timers@8.1.1": {}
+
+  "@types/sizzle@2.3.10": {}
+
   "@types/stack-utils@2.0.3": {}
 
   "@types/yargs-parser@21.0.3": {}
@@ -5695,7 +6455,10 @@ snapshots:
     dependencies:
       "@types/yargs-parser": 21.0.3
 
-  "@ungap/structured-clone@1.3.0": {}
+  "@types/yauzl@2.10.3":
+    dependencies:
+      "@types/node": 20.19.14
+    optional: true
 
   JSONStream@1.3.5:
     dependencies:
@@ -5734,6 +6497,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-colors@4.1.3: {}
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -5765,6 +6530,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  arch@2.2.0: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -5775,7 +6542,21 @@ snapshots:
 
   array-ify@1.0.0: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
+  astral-regex@2.0.0: {}
+
+  asynckit@0.4.0: {}
+
   at-least-node@1.0.0: {}
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
 
   babel-jest@29.7.0(@babel/core@7.28.4):
     dependencies:
@@ -5838,6 +6619,10 @@ snapshots:
 
   baseline-browser-mapping@2.8.3: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   before-after-hook@4.0.0: {}
 
   bl@4.1.0:
@@ -5845,6 +6630,10 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  blob-util@2.0.2: {}
+
+  bluebird@3.7.2: {}
 
   bottleneck@2.19.5: {}
 
@@ -5869,6 +6658,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  buffer-crc32@0.2.13: {}
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -5878,6 +6669,16 @@ snapshots:
 
   cachedir@2.3.0: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   callsites@3.1.0: {}
 
   camelcase@5.3.1: {}
@@ -5885,6 +6686,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001741: {}
+
+  caseless@0.12.0: {}
 
   chalk@2.4.2:
     dependencies:
@@ -5903,7 +6706,11 @@ snapshots:
 
   chardet@0.7.0: {}
 
+  check-more-types@2.24.0: {}
+
   ci-info@3.9.0: {}
+
+  ci-info@4.3.0: {}
 
   cjs-module-lexer@1.4.3: {}
 
@@ -5932,11 +6739,22 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cli-table3@0.6.1:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      colors: 1.4.0
+
   cli-table3@0.6.5:
     dependencies:
       string-width: 4.2.3
     optionalDependencies:
       "@colors/colors": 1.5.0
+
+  cli-truncate@2.1.0:
+    dependencies:
+      slice-ansi: 3.0.0
+      string-width: 4.2.3
 
   cli-truncate@4.0.0:
     dependencies:
@@ -5977,7 +6795,16 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  colors@1.4.0:
+    optional: true
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@13.1.0: {}
+
+  commander@6.2.1: {}
 
   commitizen@4.3.1(@types/node@20.19.14)(typescript@5.9.2):
     dependencies:
@@ -5998,6 +6825,8 @@ snapshots:
     transitivePeerDependencies:
       - "@types/node"
       - typescript
+
+  common-tags@1.8.2: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -6049,6 +6878,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  core-util-is@1.0.2: {}
+
   core-util-is@1.0.3: {}
 
   cosmiconfig-typescript-loader@6.1.0(@types/node@20.19.14)(cosmiconfig@9.0.0(typescript@5.9.2))(typescript@5.9.2):
@@ -6092,6 +6923,53 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
+  cypress@15.2.0:
+    dependencies:
+      "@cypress/request": 3.0.9
+      "@cypress/xvfb": 1.2.4(supports-color@8.1.1)
+      "@types/sinonjs__fake-timers": 8.1.1
+      "@types/sizzle": 2.3.10
+      arch: 2.2.0
+      blob-util: 2.0.2
+      bluebird: 3.7.2
+      buffer: 5.7.1
+      cachedir: 2.3.0
+      chalk: 4.1.2
+      check-more-types: 2.24.0
+      ci-info: 4.3.0
+      cli-cursor: 3.1.0
+      cli-table3: 0.6.1
+      commander: 6.2.1
+      common-tags: 1.8.2
+      dayjs: 1.11.18
+      debug: 4.4.1(supports-color@8.1.1)
+      enquirer: 2.4.1
+      eventemitter2: 6.4.7
+      execa: 4.1.0
+      executable: 4.1.1
+      extract-zip: 2.0.1(supports-color@8.1.1)
+      figures: 3.2.0
+      fs-extra: 9.1.0
+      hasha: 5.2.2
+      is-installed-globally: 0.4.0
+      lazy-ass: 1.6.0
+      listr2: 3.14.0(enquirer@2.4.1)
+      lodash: 4.17.21
+      log-symbols: 4.1.0
+      minimist: 1.2.8
+      ospath: 1.2.2
+      pretty-bytes: 5.6.0
+      process: 0.11.10
+      proxy-from-env: 1.0.0
+      request-progress: 3.0.0
+      semver: 7.7.2
+      supports-color: 8.1.1
+      systeminformation: 5.27.7
+      tmp: 0.2.5
+      tree-kill: 1.2.2
+      untildify: 4.0.0
+      yauzl: 2.10.0
+
   cz-conventional-changelog@3.3.0(@types/node@20.19.14)(typescript@5.9.2):
     dependencies:
       chalk: 2.4.2
@@ -6108,9 +6986,23 @@ snapshots:
 
   dargs@8.1.0: {}
 
-  debug@4.4.1:
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
+  dayjs@1.11.18: {}
+
+  debug@3.2.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  debug@4.4.1(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   dedent@0.7.0: {}
 
@@ -6126,6 +7018,8 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  delayed-stream@1.0.0: {}
+
   detect-file@1.0.0: {}
 
   detect-indent@6.1.0: {}
@@ -6138,17 +7032,24 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  doctrine@3.0.0:
-    dependencies:
-      esutils: 2.0.3
-
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
 
   electron-to-chromium@1.5.218: {}
 
@@ -6159,6 +7060,15 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emojilib@2.4.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   env-ci@11.2.0:
     dependencies:
@@ -6173,6 +7083,21 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
   escalade@3.2.0: {}
 
   escape-string-regexp@1.0.5: {}
@@ -6183,61 +7108,62 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-scope@7.2.2:
+  eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint@8.57.1:
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.36.0(jiti@2.5.1):
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.0(eslint@8.57.1)
+      "@eslint-community/eslint-utils": 4.9.0(eslint@9.36.0(jiti@2.5.1))
       "@eslint-community/regexpp": 4.12.1
-      "@eslint/eslintrc": 2.1.4
-      "@eslint/js": 8.57.1
-      "@humanwhocodes/config-array": 0.13.0
+      "@eslint/config-array": 0.21.0
+      "@eslint/config-helpers": 0.3.1
+      "@eslint/core": 0.15.2
+      "@eslint/eslintrc": 3.3.1
+      "@eslint/js": 9.36.0
+      "@eslint/plugin-kit": 0.3.5
+      "@humanfs/node": 0.16.7
       "@humanwhocodes/module-importer": 1.0.1
-      "@nodelib/fs.walk": 1.2.8
-      "@ungap/structured-clone": 1.3.0
+      "@humanwhocodes/retry": 0.4.3
+      "@types/estree": 1.0.8
+      "@types/json-schema": 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
-      doctrine: 3.0.0
+      debug: 4.4.1(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
       esquery: 1.6.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
+      file-entry-cache: 8.0.0
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.24.0
-      graphemer: 1.4.0
       ignore: 5.3.2
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
+    optionalDependencies:
+      jiti: 2.5.1
     transitivePeerDependencies:
       - supports-color
 
-  espree@9.6.1:
+  espree@10.4.0:
     dependencies:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 3.4.3
+      eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
 
@@ -6253,7 +7179,21 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter2@6.4.7: {}
+
   eventemitter3@5.0.1: {}
+
+  execa@4.1.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 5.2.0
+      human-signals: 1.1.1
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
 
   execa@5.1.1:
     dependencies:
@@ -6294,6 +7234,10 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  executable@4.1.1:
+    dependencies:
+      pify: 2.3.0
+
   exit@0.1.2: {}
 
   expand-tilde@2.0.2:
@@ -6308,11 +7252,25 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  extend@3.0.2: {}
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  extract-zip@2.0.1(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.1(supports-color@8.1.1)
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      "@types/yauzl": 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
+  extsprintf@1.3.0: {}
 
   fast-content-type-parse@3.0.0: {}
 
@@ -6324,13 +7282,13 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastq@1.19.1:
-    dependencies:
-      reusify: 1.1.0
-
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -6348,9 +7306,9 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
-  file-entry-cache@6.0.1:
+  file-entry-cache@8.0.0:
     dependencies:
-      flat-cache: 3.2.0
+      flat-cache: 4.0.1
 
   fill-range@7.1.1:
     dependencies:
@@ -6397,13 +7355,22 @@ snapshots:
       micromatch: 4.0.8
       resolve-dir: 1.0.1
 
-  flat-cache@3.2.0:
+  flat-cache@4.0.1:
     dependencies:
       flatted: 3.3.3
       keyv: 4.5.4
-      rimraf: 3.0.2
 
   flatted@3.3.3: {}
+
+  forever-agent@0.6.1: {}
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   from2@2.3.0:
     dependencies:
@@ -6438,7 +7405,29 @@ snapshots:
 
   get-east-asian-width@1.4.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.3
 
   get-stream@6.0.1: {}
 
@@ -6450,6 +7439,10 @@ snapshots:
     dependencies:
       "@sec-ant/readable-stream": 0.4.1
       is-stream: 4.0.1
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
 
   git-log-parser@1.2.1:
     dependencies:
@@ -6483,6 +7476,10 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
+  global-dirs@3.0.1:
+    dependencies:
+      ini: 2.0.0
+
   global-modules@1.0.0:
     dependencies:
       global-prefix: 1.0.2
@@ -6497,17 +7494,15 @@ snapshots:
       is-windows: 1.0.2
       which: 1.3.1
 
-  globals@13.24.0:
-    dependencies:
-      type-fest: 0.20.2
+  globals@14.0.0: {}
 
   globals@16.4.0: {}
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
-
-  graphemer@1.4.0: {}
 
   handlebars@4.7.8:
     dependencies:
@@ -6521,6 +7516,17 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasha@5.2.2:
+    dependencies:
+      is-stream: 2.0.1
+      type-fest: 0.8.1
 
   hasown@2.0.2:
     dependencies:
@@ -6547,16 +7553,24 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  http-signature@1.4.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 2.0.2
+      sshpk: 1.18.0
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  human-signals@1.1.1: {}
 
   human-signals@2.1.0: {}
 
@@ -6581,7 +7595,7 @@ snapshots:
 
   import-from-esm@2.0.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       import-meta-resolve: 4.2.0
     transitivePeerDependencies:
       - supports-color
@@ -6609,6 +7623,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ini@2.0.0: {}
 
   ini@4.1.1: {}
 
@@ -6657,6 +7673,11 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-installed-globally@0.4.0:
+    dependencies:
+      global-dirs: 3.0.1
+      is-path-inside: 3.0.3
+
   is-interactive@1.0.0: {}
 
   is-number@7.0.0: {}
@@ -6677,6 +7698,8 @@ snapshots:
     dependencies:
       text-extensions: 2.4.0
 
+  is-typedarray@1.0.0: {}
+
   is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
@@ -6688,6 +7711,8 @@ snapshots:
   isarray@1.0.0: {}
 
   isexe@2.0.0: {}
+
+  isstream@0.1.2: {}
 
   issue-parser@7.0.1:
     dependencies:
@@ -6727,7 +7752,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -7061,6 +8086,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbn@0.1.1: {}
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -7073,7 +8100,11 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
 
@@ -7085,11 +8116,20 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
+  jsprim@2.0.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
   kleur@3.0.3: {}
+
+  lazy-ass@1.6.0: {}
 
   leven@3.1.0: {}
 
@@ -7106,7 +8146,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       commander: 13.1.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       execa: 8.0.1
       lilconfig: 3.1.3
       listr2: 8.3.3
@@ -7116,6 +8156,19 @@ snapshots:
       yaml: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  listr2@3.14.0(enquirer@2.4.1):
+    dependencies:
+      cli-truncate: 2.1.0
+      colorette: 2.0.20
+      log-update: 4.0.0
+      p-map: 4.0.0
+      rfdc: 1.4.1
+      rxjs: 7.8.2
+      through: 2.3.8
+      wrap-ansi: 7.0.0
+    optionalDependencies:
+      enquirer: 2.4.1
 
   listr2@8.3.3:
     dependencies:
@@ -7170,6 +8223,8 @@ snapshots:
 
   lodash.mergewith@4.6.2: {}
 
+  lodash.once@4.1.1: {}
+
   lodash.snakecase@4.1.1: {}
 
   lodash.startcase@4.4.0: {}
@@ -7186,6 +8241,13 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  log-update@4.0.0:
+    dependencies:
+      ansi-escapes: 4.3.2
+      cli-cursor: 3.1.0
+      slice-ansi: 4.0.0
+      wrap-ansi: 6.2.0
 
   log-update@6.1.0:
     dependencies:
@@ -7224,6 +8286,8 @@ snapshots:
 
   marked@15.0.12: {}
 
+  math-intrinsics@1.1.0: {}
+
   meow@12.1.1: {}
 
   meow@13.2.0: {}
@@ -7236,6 +8300,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime@4.1.0: {}
 
@@ -7307,6 +8377,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -7345,6 +8417,8 @@ snapshots:
       wcwidth: 1.0.1
 
   os-tmpdir@1.0.2: {}
+
+  ospath@1.2.2: {}
 
   p-each-series@3.0.0: {}
 
@@ -7385,6 +8459,10 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
+
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
 
   p-map@7.0.3: {}
 
@@ -7446,6 +8524,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pend@1.2.0: {}
+
+  performance-now@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -7453,6 +8535,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  pify@2.3.0: {}
 
   pify@3.0.0: {}
 
@@ -7471,6 +8555,8 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty-bytes@5.6.0: {}
+
   pretty-format@29.7.0:
     dependencies:
       "@jest/schemas": 29.6.3
@@ -7483,6 +8569,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process@0.11.10: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -7490,11 +8578,20 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  proxy-from-env@1.0.0: {}
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
 
-  queue-microtask@1.2.3: {}
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
 
   rc@1.2.8:
     dependencies:
@@ -7539,6 +8636,10 @@ snapshots:
     dependencies:
       "@pnpm/npm-conf": 2.3.1
 
+  request-progress@3.0.0:
+    dependencies:
+      throttleit: 1.0.1
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -7576,19 +8677,9 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  reusify@1.1.0: {}
-
   rfdc@1.4.1: {}
 
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
-
   run-async@2.4.1: {}
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
 
   rxjs@7.8.2:
     dependencies:
@@ -7609,7 +8700,7 @@ snapshots:
       "@semantic-release/release-notes-generator": 14.1.0(semantic-release@24.2.8(typescript@5.9.2))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.9.2)
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       env-ci: 11.2.0
       execa: 9.6.0
       figures: 6.1.0
@@ -7651,6 +8742,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7668,6 +8787,18 @@ snapshots:
       unicode-emoji-modifier-base: 1.0.0
 
   slash@3.0.0: {}
+
+  slice-ansi@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   slice-ansi@5.0.0:
     dependencies:
@@ -7709,6 +8840,18 @@ snapshots:
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
+
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
 
   stack-utils@2.0.6:
     dependencies:
@@ -7792,6 +8935,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  systeminformation@5.27.7: {}
+
   temp-dir@3.0.0: {}
 
   tempy@3.1.0:
@@ -7809,8 +8954,6 @@ snapshots:
 
   text-extensions@2.4.0: {}
 
-  text-table@0.2.0: {}
-
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -7818,6 +8961,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  throttleit@1.0.1: {}
 
   through2@2.0.5:
     dependencies:
@@ -7837,9 +8982,17 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
+
+  tmp@0.2.5: {}
 
   tmpl@1.0.5: {}
 
@@ -7847,9 +9000,21 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   traverse@0.6.8: {}
 
+  tree-kill@1.2.2: {}
+
   tslib@2.8.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  tweetnacl@0.14.5: {}
 
   type-check@0.4.0:
     dependencies:
@@ -7857,9 +9022,9 @@ snapshots:
 
   type-detect@4.0.8: {}
 
-  type-fest@0.20.2: {}
-
   type-fest@0.21.3: {}
+
+  type-fest@0.8.1: {}
 
   type-fest@1.4.0: {}
 
@@ -7888,6 +9053,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  untildify@4.0.0: {}
+
   update-browserslist-db@1.1.3(browserslist@4.26.0):
     dependencies:
       browserslist: 4.26.0
@@ -7902,6 +9069,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@8.3.2: {}
+
   v8-to-istanbul@9.3.0:
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
@@ -7912,6 +9081,12 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
 
   walker@1.0.8:
     dependencies:
@@ -7932,6 +9107,12 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -7983,6 +9164,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/tests/lib/rules/no-hard-coded-timeout.test.js
+++ b/tests/lib/rules/no-hard-coded-timeout.test.js
@@ -1,0 +1,543 @@
+/**
+ * @fileoverview Tests for no-hard-coded-timeout rule
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/no-hard-coded-timeout');
+const { RuleTester } = require('eslint');
+
+// Detect ESLint version for proper RuleTester configuration
+const eslintPackage = require('eslint/package.json');
+const eslintVersion = parseInt(eslintPackage.version.split('.')[0], 10);
+
+// Configure RuleTester based on ESLint version
+const ruleTesterConfig = eslintVersion >= 9
+  ? {
+      // ESLint 9+ (flat config)
+      languageOptions: {
+        ecmaVersion: 2021,
+        sourceType: 'module'
+      }
+    }
+  : {
+      // ESLint 7-8 (legacy config)
+      parserOptions: {
+        ecmaVersion: 2021,
+        sourceType: 'module'
+      }
+    };
+
+const ruleTester = new RuleTester(ruleTesterConfig);
+
+ruleTester.run('no-hard-coded-timeout', rule, {
+  valid: [
+    // Should not trigger on non-test files
+    {
+      code: 'setTimeout(() => {}, 5000)',
+      filename: 'app.js'
+    },
+    // Should not trigger on small timeouts (< maxTimeout)
+    {
+      code: 'setTimeout(() => {}, 500)',
+      filename: 'test.spec.js',
+      options: [{ maxTimeout: 1000 }]
+    },
+    // Should not trigger on variable delays
+    {
+      code: 'const delay = 1000; setTimeout(() => {}, delay)',
+      filename: 'test.spec.js'
+    },
+    // Should not trigger on mock contexts
+    {
+      code: 'jest.setTimeout(5000)',
+      filename: 'test.spec.js'
+    },
+    {
+      code: 'vi.setTimeout(5000)',
+      filename: 'test.spec.js'
+    },
+    // Should allow in setup when configured
+    {
+      code: 'beforeEach(() => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: true }]
+    },
+    // Should not trigger on aliases without numbers
+    {
+      code: 'cy.wait("@apiCall")',
+      filename: 'test.cy.js'
+    },
+    // Should not trigger on non-numeric arguments
+    {
+      code: 'setTimeout(() => {}, process.env.TIMEOUT)',
+      filename: 'test.spec.js'
+    },
+    // Should allow in afterAll when configured
+    {
+      code: 'afterAll(() => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: true }]
+    },
+    // Should allow in beforeAll when configured
+    {
+      code: 'beforeAll(() => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: true }]
+    },
+    // Should allow in afterEach when configured
+    {
+      code: 'afterEach(() => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: true }]
+    },
+    // Should not trigger on Promise with non-setTimeout body
+    {
+      code: 'async function test() { await new Promise(resolve => { someFunction(resolve); }) }',
+      filename: 'test.spec.js'
+    },
+    // Should not trigger on Promise with arrow function without setTimeout
+    {
+      code: 'async function test() { await new Promise(resolve => doSomething(resolve)) }',
+      filename: 'test.spec.js'
+    },
+    // Should not trigger when delay is a string (even if numeric)
+    {
+      code: 'setTimeout(() => {}, "2000")',
+      filename: 'test.spec.js'
+    },
+    // Should not trigger on setInterval in mock context
+    {
+      code: 'jest.fn().mockImplementation(() => setInterval(() => {}, 1000))',
+      filename: 'test.spec.js'
+    },
+    // Promise with block but no statements
+    {
+      code: 'async function test() { await new Promise(resolve => { }) }',
+      filename: 'test.spec.js'
+    },
+    // Promise with block and non-setTimeout statement
+    {
+      code: 'async function test() { await new Promise(resolve => { resolve(); }) }',
+      filename: 'test.spec.js'
+    },
+    // Test in after hook (not afterEach/afterAll)
+    {
+      code: 'after(() => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: true }]
+    },
+    // Test in before hook (not beforeEach/beforeAll)
+    {
+      code: 'before(() => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: true }]
+    },
+    // Promise with non-arrow function argument (line 145 coverage)
+    {
+      code: 'async function test() { await new Promise(function(resolve) { doSomething(resolve); }) }',
+      filename: 'test.spec.js'
+    },
+    // Promise with setTimeout but delay below maxTimeout (line 171 coverage)
+    {
+      code: 'async function test() { await new Promise(resolve => setTimeout(resolve, 500)) }',
+      filename: 'test.spec.js',
+      options: [{ maxTimeout: 1000 }]
+    },
+    // Wait helper with delay below maxTimeout (line 217 coverage)
+    {
+      code: 'async function test() { await wait(500) }',
+      filename: 'test.spec.js',
+      options: [{ maxTimeout: 1000 }]
+    },
+    // setTimeout not in setup/teardown (line 239 coverage)
+    {
+      code: 'it("test", () => { const x = () => { setTimeout(() => {}, 500) }; x(); })',
+      filename: 'test.spec.js',
+      options: [{ maxTimeout: 1000, allowInSetup: true }]
+    },
+    // Promise with setTimeout but delay is not a literal
+    {
+      code: 'async function test() { await new Promise(resolve => setTimeout(resolve, someTimeout)) }',
+      filename: 'test.spec.js'
+    }
+  ],
+
+  invalid: [
+    // Basic setTimeout violation
+    {
+      code: 'async function test() { setTimeout(() => { console.log("done") }, 2000) }',
+      filename: 'test.spec.js',
+      errors: [
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 2000 }
+        }
+      ],
+      output: 'async function test() { await waitFor(async () => {\n  console.log("done")\n}, { timeout: 2000 }) }'
+    },
+    // setInterval violation
+    {
+      code: 'setInterval(() => {}, 1000)',
+      filename: 'test.spec.js',
+      errors: [
+        {
+          messageId: 'avoidSetInterval'
+        }
+      ]
+    },
+    // Promise-based timeout
+    {
+      code: 'async function test() { await new Promise(resolve => setTimeout(resolve, 3000)) }',
+      filename: 'test.spec.js',
+      errors: [
+        {
+          messageId: 'avoidPromiseTimeout'
+        },
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 3000 }
+        }
+      ],
+      output: 'async function test() { await waitFor(() => expect(true).toBe(true), { timeout: 3000 }) }'
+    },
+    // Cypress wait with number
+    {
+      code: 'cy.wait(5000)',
+      filename: 'test.cy.js',
+      errors: [
+        {
+          messageId: 'avoidCypressWait'
+        }
+      ]
+    },
+    // Wait helper functions
+    {
+      code: 'async function test() { await wait(2000) }',
+      filename: 'test.spec.js',
+      errors: [
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 2000 }
+        }
+      ]
+    },
+    {
+      code: 'async function test() { await delay(1500) }',
+      filename: 'test.spec.js',
+      errors: [
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 1500 }
+        }
+      ]
+    },
+    {
+      code: 'async function test() { await sleep(3000) }',
+      filename: 'test.spec.js',
+      errors: [
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 3000 }
+        }
+      ]
+    },
+    {
+      code: 'async function test() { await pause(2500) }',
+      filename: 'test.spec.js',
+      errors: [
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 2500 }
+        }
+      ]
+    },
+    // Global setTimeout
+    {
+      code: 'async function test() { window.setTimeout(() => {}, 2000) }',
+      filename: 'test.spec.js',
+      errors: [
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 2000 }
+        }
+      ],
+      output: 'async function test() { await waitFor(async () => {\n  \n}, { timeout: 2000 }) }'
+    },
+    // Custom maxTimeout setting
+    {
+      code: 'async function test() { setTimeout(() => {}, 100) }',
+      filename: 'test.spec.js',
+      options: [{ maxTimeout: 50 }],
+      errors: [
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 100 }
+        }
+      ],
+      output: 'async function test() { await waitFor(async () => {\n  \n}, { timeout: 100 }) }'
+    },
+    // Should report in setup when not allowed
+    {
+      code: 'beforeEach(async () => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: false }],
+      errors: [
+        {
+          messageId: 'avoidHardTimeout',
+          data: { timeout: 2000 }
+        }
+      ],
+      output: 'beforeEach(async () => { await waitFor(async () => {\n  \n}, { timeout: 2000 }) })'
+    },
+    // Multiple violations
+    {
+      code: `
+        it('test', async () => {
+          setTimeout(() => {}, 2000);
+          await new Promise(r => setTimeout(r, 3000));
+          cy.wait(4000);
+        })
+      `,
+      filename: 'test.spec.js',
+      errors: [
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } },
+        { messageId: 'avoidPromiseTimeout' },
+        { messageId: 'avoidHardTimeout', data: { timeout: 3000 } },
+        { messageId: 'avoidCypressWait' }
+      ],
+      output: '\n        it(\'test\', async () => {\n          await waitFor(async () => {\n  \n}, { timeout: 2000 });\n          await waitFor(() => expect(true).toBe(true), { timeout: 3000 });\n          cy.wait(4000);\n        })\n      '
+    },
+    // Nested setTimeout
+    {
+      code: `async function test() {
+        setTimeout(() => {
+          setTimeout(() => {}, 2000);
+        }, 1000);
+      }`,
+      filename: 'test.spec.js',
+      errors: [
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } },
+        { messageId: 'avoidHardTimeout', data: { timeout: 1000 } }
+      ],
+      output: `async function test() {
+        await waitFor(async () => {
+  setTimeout(() => {}, 2000);
+}, { timeout: 1000 });
+      }`
+    },
+    // Promise with block statement body containing setTimeout
+    {
+      code: 'async function test() { await new Promise(resolve => { setTimeout(resolve, 2000); }) }',
+      filename: 'test.spec.js',
+      errors: [
+        { messageId: 'avoidPromiseTimeout' },
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } }
+      ],
+      output: 'async function test() { await waitFor(() => expect(true).toBe(true), { timeout: 2000 }) }'
+    },
+    // Arrow function with expression body in setTimeout
+    {
+      code: 'async function test() { setTimeout(() => console.log("test"), 2000) }',
+      filename: 'test.spec.js',
+      errors: [
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } }
+      ],
+      output: 'async function test() { await waitFor(async () => console.log("test"), { timeout: 2000 }) }'
+    },
+    // setTimeout with non-function first argument
+    {
+      code: 'async function test() { setTimeout(myCallback, 2000) }',
+      filename: 'test.spec.js',
+      errors: [
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } }
+      ],
+      output: 'async function test() { await waitFor(async () => {\n  myCallback\n}, { timeout: 2000 }) }'
+    },
+    // Test isInMockContext edge case - setInterval in non-mock context
+    {
+      code: 'window.setInterval(() => {}, 1000)',
+      filename: 'test.spec.js',
+      errors: [
+        { messageId: 'avoidSetInterval' }
+      ]
+    },
+    // Test in afterAll hook with allowInSetup false
+    {
+      code: 'afterAll(async () => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: false }],
+      errors: [
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } }
+      ],
+      output: 'afterAll(async () => { await waitFor(async () => {\n  \n}, { timeout: 2000 }) })'
+    },
+    // Test in beforeAll hook with allowInSetup false
+    {
+      code: 'beforeAll(async () => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: false }],
+      errors: [
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } }
+      ],
+      output: 'beforeAll(async () => { await waitFor(async () => {\n  \n}, { timeout: 2000 }) })'
+    },
+    // Test in afterEach hook with allowInSetup false
+    {
+      code: 'afterEach(async () => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: false }],
+      errors: [
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } }
+      ],
+      output: 'afterEach(async () => { await waitFor(async () => {\n  \n}, { timeout: 2000 }) })'
+    },
+    // Test setTimeout outside setup with allowInSetup true (should still error - line 239 coverage)
+    {
+      code: 'it("test", () => { setTimeout(() => {}, 2000) })',
+      filename: 'test.spec.js',
+      options: [{ allowInSetup: true }],
+      errors: [
+        { messageId: 'avoidHardTimeout', data: { timeout: 2000 } }
+      ],
+      output: 'it("test", () => { waitFor(async () => {\n  \n}, { timeout: 2000 }) })'
+    }
+  ]
+});
+
+// Unit tests for helper functions
+describe('no-hard-coded-timeout rule internals', () => {
+  it('should export a rule object', () => {
+    expect(rule).toBeDefined();
+    expect(rule.meta).toBeDefined();
+    expect(rule.create).toBeDefined();
+  });
+
+  it('should have correct meta information', () => {
+    expect(rule.meta.type).toBe('problem');
+    expect(rule.meta.docs.description).toBe('Disallow hard-coded timeouts in tests');
+    expect(rule.meta.fixable).toBe('code');
+    expect(rule.meta.messages).toHaveProperty('avoidHardTimeout');
+    expect(rule.meta.messages).toHaveProperty('avoidSetInterval');
+    expect(rule.meta.messages).toHaveProperty('avoidPromiseTimeout');
+    expect(rule.meta.messages).toHaveProperty('avoidCypressWait');
+  });
+
+  it('should have schema with correct options', () => {
+    expect(rule.meta.schema).toHaveLength(1);
+    expect(rule.meta.schema[0].type).toBe('object');
+    expect(rule.meta.schema[0].properties).toHaveProperty('maxTimeout');
+    expect(rule.meta.schema[0].properties.maxTimeout.default).toBe(1000);
+    expect(rule.meta.schema[0].properties).toHaveProperty('allowInSetup');
+    expect(rule.meta.schema[0].properties.allowInSetup.default).toBe(false);
+  });
+
+  it('should return empty object for non-test files', () => {
+    const context = {
+      options: [],
+      getFilename: () => 'app.js',
+      getPhysicalFilename: () => 'app.js',
+      filename: 'app.js',
+      report: jest.fn()
+    };
+
+    const visitor = rule.create(context);
+    expect(visitor).toEqual({});
+  });
+
+  it('should create proper visitor for test files', () => {
+    const context = {
+      options: [],
+      getFilename: () => 'test.spec.js',
+      getPhysicalFilename: () => 'test.spec.js',
+      filename: 'test.spec.js',
+      report: jest.fn(),
+      getSourceCode: () => ({
+        getText: () => 'code'
+      })
+    };
+
+    const visitor = rule.create(context);
+    expect(visitor).toBeDefined();
+    expect(visitor.CallExpression).toBeDefined();
+    expect(visitor.NewExpression).toBeDefined();
+  });
+
+  describe('Edge cases', () => {
+    it('should handle setTimeout without delay argument', () => {
+      const context = {
+        options: [],
+        getFilename: () => 'test.spec.js',
+        getPhysicalFilename: () => 'test.spec.js',
+        filename: 'test.spec.js',
+        report: jest.fn(),
+        getSourceCode: () => ({
+          getText: () => '() => {}'
+        })
+      };
+
+      const visitor = rule.create(context);
+      const node = {
+        type: 'CallExpression',
+        callee: { name: 'setTimeout' },
+        arguments: [{ type: 'ArrowFunctionExpression' }],
+        parent: null
+      };
+
+      visitor.CallExpression(node);
+      expect(context.report).not.toHaveBeenCalled();
+    });
+
+    it('should handle Promise without setTimeout', () => {
+      const context = {
+        options: [],
+        getFilename: () => 'test.spec.js',
+        getPhysicalFilename: () => 'test.spec.js',
+        filename: 'test.spec.js',
+        report: jest.fn()
+      };
+
+      const visitor = rule.create(context);
+      const node = {
+        type: 'NewExpression',
+        callee: { name: 'Promise' },
+        arguments: [
+          {
+            type: 'ArrowFunctionExpression',
+            body: { type: 'BlockStatement' }
+          }
+        ]
+      };
+
+      visitor.NewExpression(node);
+      expect(context.report).not.toHaveBeenCalled();
+    });
+
+    it('should handle Cypress wait with string alias', () => {
+      const context = {
+        options: [],
+        getFilename: () => 'test.cy.js',
+        getPhysicalFilename: () => 'test.cy.js',
+        filename: 'test.cy.js',
+        report: jest.fn(),
+        getSourceCode: () => ({
+          getText: () => 'cy.wait'
+        })
+      };
+
+      const visitor = rule.create(context);
+      const node = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          object: { name: 'cy' },
+          property: { name: 'wait' }
+        },
+        arguments: [{ type: 'Literal', value: '@apiCall' }]
+      };
+
+      visitor.CallExpression(node);
+      expect(context.report).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/lib/utils/helpers.test.js
+++ b/tests/lib/utils/helpers.test.js
@@ -1,0 +1,941 @@
+/**
+ * @fileoverview Tests for utility helper functions
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const helpers = require('../../../lib/utils/helpers');
+
+describe('helpers', () => {
+  describe('isTestFile', () => {
+    it('should return false for non-test files', () => {
+      expect(helpers.isTestFile('app.js')).toBe(false);
+      expect(helpers.isTestFile('index.jsx')).toBe(false);
+      expect(helpers.isTestFile('utils.ts')).toBe(false);
+      expect(helpers.isTestFile('config.json')).toBe(false);
+    });
+
+    it('should return true for test files with .test extension', () => {
+      expect(helpers.isTestFile('app.test.js')).toBe(true);
+      expect(helpers.isTestFile('component.test.jsx')).toBe(true);
+      expect(helpers.isTestFile('utils.test.ts')).toBe(true);
+      expect(helpers.isTestFile('module.test.tsx')).toBe(true);
+      expect(helpers.isTestFile('file.test.mjs')).toBe(true);
+      expect(helpers.isTestFile('file.test.cjs')).toBe(true);
+    });
+
+    it('should return true for test files with .spec extension', () => {
+      expect(helpers.isTestFile('app.spec.js')).toBe(true);
+      expect(helpers.isTestFile('component.spec.jsx')).toBe(true);
+      expect(helpers.isTestFile('utils.spec.ts')).toBe(true);
+      expect(helpers.isTestFile('module.spec.tsx')).toBe(true);
+    });
+
+    it('should return true for story test files', () => {
+      expect(helpers.isTestFile('Button.test.stories.js')).toBe(true);
+      expect(helpers.isTestFile('Card.spec.stories.tsx')).toBe(true);
+    });
+
+    it('should return true for files in __tests__ directory', () => {
+      expect(helpers.isTestFile('src/__tests__/app.js')).toBe(true);
+      expect(helpers.isTestFile('path/__tests__/utils.ts')).toBe(true);
+    });
+
+    it('should return true for files in test/tests/spec/specs directories', () => {
+      expect(helpers.isTestFile('src/test/app.js')).toBe(true);
+      expect(helpers.isTestFile('src/tests/utils.ts')).toBe(true);
+      expect(helpers.isTestFile('src/spec/component.jsx')).toBe(true);
+      expect(helpers.isTestFile('src/specs/module.tsx')).toBe(true);
+    });
+
+    it('should return true for e2e and integration test files', () => {
+      expect(helpers.isTestFile('app.e2e.js')).toBe(true);
+      expect(helpers.isTestFile('flow.integration.ts')).toBe(true);
+      expect(helpers.isTestFile('test.cy.js')).toBe(true);
+    });
+
+    it('should return true for files in cypress or playwright directories', () => {
+      expect(helpers.isTestFile('/cypress/integration/app.js')).toBe(true);
+      expect(helpers.isTestFile('tests/cypress/utils.ts')).toBe(true);
+      expect(helpers.isTestFile('/playwright/tests/e2e.js')).toBe(true);
+    });
+
+    it('should return true for cucumber step definitions', () => {
+      expect(helpers.isTestFile('login.steps.js')).toBe(true);
+      expect(helpers.isTestFile('checkout.step.ts')).toBe(true);
+    });
+
+    it('should return false for null or undefined filename', () => {
+      expect(helpers.isTestFile(null)).toBe(false);
+      expect(helpers.isTestFile(undefined)).toBe(false);
+      expect(helpers.isTestFile('')).toBe(false);
+    });
+  });
+
+  describe('isInMockContext', () => {
+    const createMockContext = () => ({
+      getSourceCode: () => ({
+        getText: (node) => {
+          if (node && node.mockText) return node.mockText;
+          if (node && node.name) return node.name;
+          if (node && node.object && node.property) {
+            return `${node.object.name}.${node.property.name}`;
+          }
+          return 'someFunction';
+        }
+      })
+    });
+
+    it('should detect jest mock calls', () => {
+      const context = createMockContext();
+      const node = {
+        callee: {
+          object: { name: 'jest' },
+          property: { name: 'mock' },
+          mockText: 'jest.mock'
+        }
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should detect vitest mock calls', () => {
+      const context = createMockContext();
+      const node = {
+        callee: {
+          object: { name: 'vi' },
+          property: { name: 'fn' },
+          mockText: 'vi.fn'
+        }
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should detect sinon mock calls', () => {
+      const context = createMockContext();
+      const node = {
+        callee: {
+          mockText: 'sinon.stub'
+        }
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should detect mock/stub/spy/fake patterns', () => {
+      const context = createMockContext();
+
+      const mockNode = { callee: { mockText: 'mockFunction' } };
+      expect(helpers.isInMockContext(mockNode, context)).toBe(true);
+
+      const stubNode = { callee: { mockText: 'stubMethod' } };
+      expect(helpers.isInMockContext(stubNode, context)).toBe(true);
+
+      const spyNode = { callee: { mockText: 'spyOn' } };
+      expect(helpers.isInMockContext(spyNode, context)).toBe(true);
+
+      const fakeNode = { callee: { mockText: 'fakeTimer' } };
+      expect(helpers.isInMockContext(fakeNode, context)).toBe(true);
+    });
+
+    it('should detect mock calls with member expressions', () => {
+      const context = createMockContext();
+      const node = {
+        callee: {
+          mockText: 'service.mockImplementation'
+        }
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should detect mock context in parent nodes', () => {
+      const context = createMockContext();
+      const mockParent = {
+        type: 'CallExpression',
+        callee: { mockText: 'jest.mock' }
+      };
+      const node = {
+        parent: mockParent
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should detect jest.mock() module mocking in parent', () => {
+      const context = createMockContext();
+      const mockParent = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          object: { name: 'jest' },
+          property: { name: 'mock' }
+        }
+      };
+      const node = {
+        parent: {
+          parent: mockParent
+        }
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should detect vi.mock() module mocking in parent', () => {
+      const context = createMockContext();
+      const mockParent = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          object: { name: 'vi' },
+          property: { name: 'mock' }
+        }
+      };
+      const node = {
+        parent: mockParent
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should detect mock in deeply nested parent', () => {
+      const context = createMockContext();
+      const mockGrandparent = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          object: { name: 'jest' },
+          property: { name: 'mock' }
+        },
+        parent: null
+      };
+      const middleParent = {
+        type: 'BlockStatement',
+        parent: mockGrandparent
+      };
+      const node = {
+        parent: middleParent
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should detect jest.mock in parent when regex doesnt match', () => {
+      const context = {
+        getSourceCode: () => ({
+          getText: (node) => {
+            // Return text that doesn't match the regex but has the right structure
+            if (node && node.type === 'MemberExpression') {
+              return 'something.else';  // This won't match the regex
+            }
+            return 'otherFunction';
+          }
+        })
+      };
+
+      const mockGrandparent = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          object: { name: 'jest' },
+          property: { name: 'mock' }
+        },
+        parent: null
+      };
+
+      const node = {
+        parent: mockGrandparent
+      };
+
+      expect(helpers.isInMockContext(node, context)).toBe(true);
+    });
+
+    it('should limit parent traversal to 5 levels', () => {
+      const context = createMockContext();
+      let deepNode = { parent: null };
+      for (let i = 0; i < 10; i++) {
+        deepNode = { parent: deepNode };
+      }
+      // Place mock context at 6th level (beyond limit)
+      let current = deepNode;
+      for (let i = 0; i < 6; i++) {
+        current = current.parent;
+      }
+      current.type = 'CallExpression';
+      current.callee = { mockText: 'jest.mock' };
+
+      expect(helpers.isInMockContext(deepNode, context)).toBe(false);
+    });
+
+    it('should return false for non-mock contexts', () => {
+      const context = createMockContext();
+      const node = {
+        callee: { mockText: 'regularFunction' }
+      };
+      expect(helpers.isInMockContext(node, context)).toBe(false);
+    });
+
+    it('should handle nodes without callee', () => {
+      const context = createMockContext();
+      const node = { type: 'Identifier' };
+      expect(helpers.isInMockContext(node, context)).toBe(false);
+    });
+  });
+
+  describe('isInHook', () => {
+    it('should detect if node is in specified hooks', () => {
+      const beforeEachParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'beforeEach' }
+      };
+      const node = { parent: beforeEachParent };
+
+      expect(helpers.isInHook(node, ['beforeEach', 'afterEach'])).toBe(true);
+      expect(helpers.isInHook(node, ['beforeAll', 'afterAll'])).toBe(false);
+    });
+
+    it('should detect hooks in nested parent structure', () => {
+      const hookParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'afterAll' }
+      };
+      const node = {
+        parent: {
+          parent: {
+            parent: hookParent
+          }
+        }
+      };
+
+      expect(helpers.isInHook(node, ['afterAll'])).toBe(true);
+    });
+
+    it('should return false when not in any hook', () => {
+      const node = { parent: null };
+      expect(helpers.isInHook(node, ['beforeEach', 'afterEach'])).toBe(false);
+    });
+
+    it('should handle non-CallExpression parents', () => {
+      const node = {
+        parent: {
+          type: 'VariableDeclaration',
+          parent: null
+        }
+      };
+      expect(helpers.isInHook(node, ['beforeEach'])).toBe(false);
+    });
+
+    it('should handle callee that is not an Identifier', () => {
+      const node = {
+        parent: {
+          type: 'CallExpression',
+          callee: { type: 'MemberExpression' }
+        }
+      };
+      expect(helpers.isInHook(node, ['beforeEach'])).toBe(false);
+    });
+  });
+
+  describe('isInDescribe', () => {
+    it('should detect if node is in describe block', () => {
+      const describeParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'describe' }
+      };
+      const node = { parent: describeParent };
+
+      expect(helpers.isInDescribe(node)).toBe(true);
+    });
+
+    it('should detect if node is in context block', () => {
+      const contextParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'context' }
+      };
+      const node = { parent: contextParent };
+
+      expect(helpers.isInDescribe(node)).toBe(true);
+    });
+
+    it('should detect if node is in suite block', () => {
+      const suiteParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'suite' }
+      };
+      const node = { parent: suiteParent };
+
+      expect(helpers.isInDescribe(node)).toBe(true);
+    });
+
+    it('should detect describe in nested parent structure', () => {
+      const describeParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'describe' }
+      };
+      const node = {
+        parent: {
+          parent: {
+            parent: describeParent
+          }
+        }
+      };
+
+      expect(helpers.isInDescribe(node)).toBe(true);
+    });
+
+    it('should return false when not in describe', () => {
+      const node = { parent: null };
+      expect(helpers.isInDescribe(node)).toBe(false);
+    });
+
+    it('should handle non-CallExpression parents', () => {
+      const node = {
+        parent: {
+          type: 'VariableDeclaration',
+          parent: null
+        }
+      };
+      expect(helpers.isInDescribe(node)).toBe(false);
+    });
+  });
+
+  describe('isInTest', () => {
+    it('should detect if node is in it block', () => {
+      const itParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'it' }
+      };
+      const node = { parent: itParent };
+
+      expect(helpers.isInTest(node)).toBe(true);
+    });
+
+    it('should detect if node is in test block', () => {
+      const testParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'test' }
+      };
+      const node = { parent: testParent };
+
+      expect(helpers.isInTest(node)).toBe(true);
+    });
+
+    it('should detect if node is in specify block', () => {
+      const specifyParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'specify' }
+      };
+      const node = { parent: specifyParent };
+
+      expect(helpers.isInTest(node)).toBe(true);
+    });
+
+    it('should detect test in nested parent structure', () => {
+      const testParent = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'test' }
+      };
+      const node = {
+        parent: {
+          parent: {
+            parent: testParent
+          }
+        }
+      };
+
+      expect(helpers.isInTest(node)).toBe(true);
+    });
+
+    it('should return false when not in test', () => {
+      const node = { parent: null };
+      expect(helpers.isInTest(node)).toBe(false);
+    });
+
+    it('should handle non-CallExpression parents', () => {
+      const node = {
+        parent: {
+          type: 'VariableDeclaration',
+          parent: null
+        }
+      };
+      expect(helpers.isInTest(node)).toBe(false);
+    });
+
+    it('should handle callee that is not an Identifier', () => {
+      const node = {
+        parent: {
+          type: 'CallExpression',
+          callee: { type: 'MemberExpression' }
+        }
+      };
+      expect(helpers.isInTest(node)).toBe(false);
+    });
+  });
+
+  describe('getFilename', () => {
+    it('should get filename from ESLint 9+ context', () => {
+      const context = { filename: '/path/to/test.js' };
+      expect(helpers.getFilename(context)).toBe('/path/to/test.js');
+    });
+
+    it('should get filename from ESLint 8 getPhysicalFilename', () => {
+      const context = {
+        getPhysicalFilename: () => '/path/to/test.js'
+      };
+      expect(helpers.getFilename(context)).toBe('/path/to/test.js');
+    });
+
+    it('should get filename from ESLint 7 getFilename', () => {
+      const context = {
+        getFilename: () => '/path/to/test.js'
+      };
+      expect(helpers.getFilename(context)).toBe('/path/to/test.js');
+    });
+
+    it('should return empty string when no filename method available', () => {
+      const context = {};
+      expect(helpers.getFilename(context)).toBe('');
+    });
+
+    it('should prioritize ESLint 9 filename over legacy methods', () => {
+      const context = {
+        filename: '/path/v9/test.js',
+        getPhysicalFilename: () => '/path/v8/test.js',
+        getFilename: () => '/path/v7/test.js'
+      };
+      expect(helpers.getFilename(context)).toBe('/path/v9/test.js');
+    });
+  });
+
+  describe('getTestFramework', () => {
+    const createContext = (filename, text) => ({
+      filename,
+      getFilename: () => filename,
+      getSourceCode: () => ({
+        getText: () => text
+      })
+    });
+
+    it('should detect testing-library', () => {
+      const context = createContext(
+        'test.js',
+        'import { render } from "@testing-library/react"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('testing-library');
+    });
+
+    it('should detect playwright', () => {
+      const context = createContext(
+        'test.js',
+        'import { test } from "@playwright/test"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('playwright');
+    });
+
+    it('should detect cypress from import', () => {
+      const context = createContext(
+        'test.js',
+        'import cypress from "cypress"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('cypress');
+    });
+
+    it('should detect vitest', () => {
+      const context = createContext(
+        'test.js',
+        'import { test } from "vitest"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('vitest');
+    });
+
+    it('should detect jest from import', () => {
+      const context = createContext(
+        'test.js',
+        'import jest from "jest"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('jest');
+    });
+
+    it('should detect vitest from global usage', () => {
+      const context = createContext(
+        'test.js',
+        'describe("test", () => { vi.mock("module") })'
+      );
+      expect(helpers.getTestFramework(context)).toBe('vitest');
+    });
+
+    it('should detect jest from global usage', () => {
+      const context = createContext(
+        'test.js',
+        'describe("test", () => { jest.fn() })'
+      );
+      expect(helpers.getTestFramework(context)).toBe('jest');
+    });
+
+    it('should detect cypress from global usage', () => {
+      const context = createContext(
+        'test.js',
+        'describe("test", () => { cy.visit("/") })'
+      );
+      expect(helpers.getTestFramework(context)).toBe('cypress');
+    });
+
+    it('should detect cypress from file path', () => {
+      const context = createContext(
+        '/project/cypress/integration/test.js',
+        'const test = "code"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('cypress');
+    });
+
+    it('should detect playwright from file path', () => {
+      const context = createContext(
+        '/project/playwright/tests/test.js',
+        'const test = "code"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('playwright');
+    });
+
+    it('should detect cypress from .cy filename', () => {
+      const context = createContext(
+        'test.cy.js',
+        'const test = "code"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('cypress');
+    });
+
+    it('should default to jest for .spec files', () => {
+      const context = createContext(
+        'test.spec.js',
+        'const test = "code"'
+      );
+      expect(helpers.getTestFramework(context)).toBe('jest');
+    });
+
+    it('should return null for unknown frameworks', () => {
+      const context = createContext(
+        'test.js',
+        'const test = "code"'
+      );
+      expect(helpers.getTestFramework(context)).toBe(null);
+    });
+
+    it('should handle context without getFilename', () => {
+      const context = {
+        filename: 'test.cy.js',
+        getSourceCode: () => ({
+          getText: () => 'const test = "code"'
+        })
+      };
+      expect(helpers.getTestFramework(context)).toBe('cypress');
+    });
+  });
+
+  describe('isPromise', () => {
+    it('should detect async functions', () => {
+      const node = { async: true };
+      expect(helpers.isPromise(node)).toBe(true);
+    });
+
+    it('should detect Promise constructor', () => {
+      const node = {
+        type: 'NewExpression',
+        callee: { name: 'Promise' }
+      };
+      expect(helpers.isPromise(node)).toBe(true);
+    });
+
+    it('should detect promise methods', () => {
+      const thenNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'then' }
+        }
+      };
+      expect(helpers.isPromise(thenNode)).toBe(true);
+
+      const catchNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'catch' }
+        }
+      };
+      expect(helpers.isPromise(catchNode)).toBe(true);
+
+      const finallyNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'finally' }
+        }
+      };
+      expect(helpers.isPromise(finallyNode)).toBe(true);
+    });
+
+    it('should detect Promise static methods', () => {
+      const allNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'all' }
+        }
+      };
+      expect(helpers.isPromise(allNode)).toBe(true);
+
+      const raceNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'race' }
+        }
+      };
+      expect(helpers.isPromise(raceNode)).toBe(true);
+
+      const allSettledNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'allSettled' }
+        }
+      };
+      expect(helpers.isPromise(allSettledNode)).toBe(true);
+
+      const anyNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'any' }
+        }
+      };
+      expect(helpers.isPromise(anyNode)).toBe(true);
+
+      const resolveNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'resolve' }
+        }
+      };
+      expect(helpers.isPromise(resolveNode)).toBe(true);
+
+      const rejectNode = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'reject' }
+        }
+      };
+      expect(helpers.isPromise(rejectNode)).toBe(true);
+    });
+
+    it('should detect common async methods', () => {
+      const fetchNode = {
+        type: 'CallExpression',
+        callee: { name: 'fetch' }
+      };
+      expect(helpers.isPromise(fetchNode)).toBe(true);
+
+      const axiosNode = {
+        type: 'CallExpression',
+        callee: { name: 'axios' }
+      };
+      expect(helpers.isPromise(axiosNode)).toBe(true);
+
+      const requestNode = {
+        type: 'CallExpression',
+        callee: { name: 'request' }
+      };
+      expect(helpers.isPromise(requestNode)).toBe(true);
+
+      const getNode = {
+        type: 'CallExpression',
+        callee: { name: 'get' }
+      };
+      expect(helpers.isPromise(getNode)).toBe(true);
+
+      const postNode = {
+        type: 'CallExpression',
+        callee: { name: 'POST' }
+      };
+      expect(helpers.isPromise(postNode)).toBe(true);
+
+      const putNode = {
+        type: 'CallExpression',
+        callee: { name: 'Put' }
+      };
+      expect(helpers.isPromise(putNode)).toBe(true);
+
+      const deleteNode = {
+        type: 'CallExpression',
+        callee: { name: 'DELETE' }
+      };
+      expect(helpers.isPromise(deleteNode)).toBe(true);
+
+      const patchNode = {
+        type: 'CallExpression',
+        callee: { name: 'Patch' }
+      };
+      expect(helpers.isPromise(patchNode)).toBe(true);
+    });
+
+    it('should return false for non-promise nodes', () => {
+      expect(helpers.isPromise(null)).toBe(false);
+      expect(helpers.isPromise(undefined)).toBe(false);
+
+      const regularFunction = { async: false };
+      expect(helpers.isPromise(regularFunction)).toBe(false);
+
+      const regularCall = {
+        type: 'CallExpression',
+        callee: { name: 'regularFunction' }
+      };
+      expect(helpers.isPromise(regularCall)).toBe(false);
+
+      const nonPromiseMethod = {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: { name: 'map' }
+        }
+      };
+      expect(helpers.isPromise(nonPromiseMethod)).toBe(false);
+    });
+
+    it('should handle nodes without callee property', () => {
+      const node = { type: 'Identifier' };
+      expect(helpers.isPromise(node)).toBe(false);
+    });
+
+    it('should handle CallExpression without name', () => {
+      const node = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier' }
+      };
+      expect(helpers.isPromise(node)).toBe(false);
+    });
+  });
+
+  describe('getIndentation', () => {
+    it('should get indentation for a node', () => {
+      const node = {};
+      const context = {
+        getSourceCode: () => ({
+          getFirstToken: () => ({ loc: { start: { line: 1 } } }),
+          lines: ['    const test = 1;']
+        })
+      };
+      expect(helpers.getIndentation(node, context)).toBe('    ');
+    });
+
+    it('should handle tabs', () => {
+      const node = {};
+      const context = {
+        getSourceCode: () => ({
+          getFirstToken: () => ({ loc: { start: { line: 1 } } }),
+          lines: ['\t\tconst test = 1;']
+        })
+      };
+      expect(helpers.getIndentation(node, context)).toBe('\t\t');
+    });
+
+    it('should handle mixed spaces and tabs', () => {
+      const node = {};
+      const context = {
+        getSourceCode: () => ({
+          getFirstToken: () => ({ loc: { start: { line: 1 } } }),
+          lines: ['  \t  const test = 1;']
+        })
+      };
+      expect(helpers.getIndentation(node, context)).toBe('  \t  ');
+    });
+
+    it('should handle no indentation', () => {
+      const node = {};
+      const context = {
+        getSourceCode: () => ({
+          getFirstToken: () => ({ loc: { start: { line: 1 } } }),
+          lines: ['const test = 1;']
+        })
+      };
+      expect(helpers.getIndentation(node, context)).toBe('');
+    });
+
+    it('should handle missing token', () => {
+      const node = {};
+      const context = {
+        getSourceCode: () => ({
+          getFirstToken: () => null,
+          lines: ['const test = 1;']
+        })
+      };
+      expect(helpers.getIndentation(node, context)).toBe('');
+    });
+
+    it('should handle line index correctly', () => {
+      const node = {};
+      const context = {
+        getSourceCode: () => ({
+          getFirstToken: () => ({ loc: { start: { line: 3 } } }),
+          lines: [
+            'line 1',
+            'line 2',
+            '      const test = 1;'
+          ]
+        })
+      };
+      expect(helpers.getIndentation(node, context)).toBe('      ');
+    });
+
+    it('should handle out of bounds line index', () => {
+      const node = {};
+      const context = {
+        getSourceCode: () => ({
+          getFirstToken: () => ({ loc: { start: { line: 5 } } }),
+          lines: ['line 1', 'line 2']
+        })
+      };
+      expect(helpers.getIndentation(node, context)).toBe('');
+    });
+  });
+
+  describe('isUrl', () => {
+    it('should detect http URLs', () => {
+      expect(helpers.isUrl('http://example.com')).toBe(true);
+      expect(helpers.isUrl('https://example.com')).toBe(true);
+    });
+
+    it('should detect websocket URLs', () => {
+      expect(helpers.isUrl('ws://example.com')).toBe(true);
+      expect(helpers.isUrl('wss://example.com')).toBe(true);
+    });
+
+    it('should detect protocol-relative URLs', () => {
+      expect(helpers.isUrl('//example.com')).toBe(true);
+    });
+
+    it('should return false for non-URLs', () => {
+      expect(helpers.isUrl('example.com')).toBe(false);
+      expect(helpers.isUrl('file.txt')).toBe(false);
+      expect(helpers.isUrl('/path/to/file')).toBe(false);
+      expect(helpers.isUrl('C:\\Windows\\file.txt')).toBe(false);
+      expect(helpers.isUrl('ftp://example.com')).toBe(false);
+    });
+  });
+
+  describe('isDataUrl', () => {
+    it('should detect data URLs', () => {
+      expect(helpers.isDataUrl('data:text/plain;base64,SGVsbG8=')).toBe(true);
+      expect(helpers.isDataUrl('data:image/png;base64,iVBORw0KG')).toBe(true);
+    });
+
+    it('should detect blob URLs', () => {
+      expect(helpers.isDataUrl('blob:http://example.com/uuid')).toBe(true);
+    });
+
+    it('should detect file URLs', () => {
+      expect(helpers.isDataUrl('file:///path/to/file')).toBe(true);
+    });
+
+    it('should return false for non-data URLs', () => {
+      expect(helpers.isDataUrl('http://example.com')).toBe(false);
+      expect(helpers.isDataUrl('https://example.com')).toBe(false);
+      expect(helpers.isDataUrl('//example.com')).toBe(false);
+      expect(helpers.isDataUrl('example.txt')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Existing Behavior
  - No ESLint plugin structure existed in the repository
  - No configuration presets were available for test flakiness detection
  - No plugin entry point or rule loading mechanism was in place
  - No infrastructure for organizing and exporting ESLint rules

  ## Intended New Behavior
  - ESLint plugin foundation with main entry point at lib/index.js
  - Two configuration presets available: recommended and strict (currently empty)
  - Dynamic rule loading using requireindex to automatically discover rules
  - Complete plugin structure with configs export including recommended, strict, and all presets

  ## Dev Checks
  - [ ] Functionality can be toggled on/off
  - [ ] New code is covered by unit/integration tests
  - [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
  - [x] There is appropriate documentation for the new work
  - [ ] Any new environment variables are populated into variable groups for all environments

  ## Testing Plan / Demo
  1. Install the plugin locally: `npm link` in the plugin directory
  2. In a test project, install the linked plugin: `npm link eslint-plugin-test-flakiness`
  3. Add the plugin to ESLint configuration:
     ```json
     {
       "plugins": ["test-flakiness"],
       "extends": ["plugin:test-flakiness/recommended"]
     }
  4. Run ESLint to verify the plugin loads without errors: npx eslint --print-config test-file.js
  5. Verify the plugin structure by checking that configs are accessible:
    - require('eslint-plugin-test-flakiness').configs.recommended
    - require('eslint-plugin-test-flakiness').configs.strict
    - require('eslint-plugin-test-flakiness').configs.all
  6. Expected result: Plugin loads successfully with empty rule configurations ready for future rule implementations