### PR TITLE
feat(rules): implement no-global-state-mutation rule

### DIFF
--- a/docs/rules/no-global-state-mutation.md
+++ b/docs/rules/no-global-state-mutation.md
@@ -1,0 +1,421 @@
+# no-global-state-mutation
+
+Prevent global state mutations that can cause test interdependencies.
+
+## Rule Details
+
+Global state mutations in tests can cause tests to depend on each other, leading to flaky behavior:
+
+- Tests may pass when run individually but fail when run together
+- Test execution order can affect results
+- Parallel test execution can cause race conditions
+- State changes in one test can leak into subsequent tests
+- Environment variables and global objects can be modified unexpectedly
+
+This rule helps prevent test flakiness by detecting mutations to global state that could affect other tests.
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+```json
+{
+  "test-flakiness/no-global-state-mutation": [
+    "error",
+    {
+      "allowInHooks": true
+    }
+  ]
+}
+```
+
+### `allowInHooks` (default: `true`)
+
+When set to `true`, allows global state mutations in setup and teardown hooks (`beforeEach`, `afterEach`, `beforeAll`, `afterAll`).
+
+```javascript
+// With allowInHooks: true (default)
+beforeEach(() => {
+  window.location.href = "http://localhost"; // ✅ Allowed
+});
+
+// With allowInHooks: false
+beforeEach(() => {
+  window.location.href = "http://localhost"; // ❌ Not allowed
+});
+```
+
+## Examples
+
+### ❌ Incorrect
+
+```javascript
+// Direct global object mutations
+window.location.href = "http://example.com";
+document.title = "Test Page";
+global.fetch = mockFetch;
+process.env.NODE_ENV = "test";
+
+// Local/Session storage mutations
+localStorage.setItem("token", "fake-token");
+sessionStorage.clear();
+
+// Console pollution
+console.log("Debug info");
+console.error("Test error");
+
+// Navigator modifications
+navigator.userAgent = "fake-agent";
+
+// Global variable creation
+globalTestVar = "some value"; // Creates global without declaration
+
+// Event listener modifications
+window.addEventListener("resize", handler);
+document.addEventListener("click", handler);
+
+// Test execution state changes
+test.only("should do something", () => {
+  // This affects global test execution
+});
+
+// Process environment mutations
+process.env.API_URL = "http://localhost:3000";
+delete process.env.NODE_ENV;
+
+// Document structure changes
+document.write("<div>Test content</div>");
+document.body.innerHTML = "<p>Test</p>";
+```
+
+### ✅ Correct
+
+```javascript
+// Use proper setup/teardown hooks
+beforeEach(() => {
+  // Setup is allowed in hooks
+  window.location.href = "http://localhost";
+  localStorage.setItem("token", "test-token");
+});
+
+afterEach(() => {
+  // Cleanup in teardown
+  localStorage.clear();
+  delete window.customProperty;
+});
+
+// Use local variables instead
+test("should handle data", () => {
+  const mockData = { id: 1, name: "test" };
+  const result = processData(mockData);
+  expect(result).toBe(expected);
+});
+
+// Mock globals properly with cleanup
+beforeEach(() => {
+  originalFetch = global.fetch;
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+// Use environment variable mocking with restore
+beforeEach(() => {
+  originalEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "test";
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv;
+});
+
+// Use proper test utilities
+test("should render correctly", () => {
+  render(<Component />);
+  expect(screen.getByText("Hello")).toBeInTheDocument();
+});
+
+// Use local scope for test data
+test("should calculate total", () => {
+  const items = [{ price: 10 }, { price: 20 }];
+  expect(calculateTotal(items)).toBe(30);
+});
+```
+
+## Best Practices
+
+### 1. Use Setup and Teardown Hooks
+
+Always use proper setup and teardown hooks for global state changes:
+
+```javascript
+describe("Component with global state", () => {
+  let originalLocation;
+
+  beforeEach(() => {
+    // Store original state
+    originalLocation = window.location.href;
+    // Set test state
+    window.location.href = "http://localhost:3000/test";
+  });
+
+  afterEach(() => {
+    // Restore original state
+    window.location.href = originalLocation;
+    // Clear any other changes
+    localStorage.clear();
+  });
+
+  test("should work with mocked location", () => {
+    // Test implementation
+  });
+});
+```
+
+### 2. Mock Globals Properly
+
+Use proper mocking techniques that include cleanup:
+
+```javascript
+describe("API tests", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+});
+```
+
+### 3. Use Test Utilities for Environment Variables
+
+Use testing utilities for environment variable management:
+
+```javascript
+// Using jest-environment-node
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  process.env.NODE_ENV = "test";
+  process.env.API_URL = "http://localhost:3000";
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+```
+
+### 4. Prefer Local Test Data
+
+Keep test data local to avoid global state pollution:
+
+```javascript
+// Instead of global test data
+globalTestData = { users: [...] };
+
+// Use local data in each test
+test('should handle users', () => {
+  const testData = { users: [{ id: 1, name: 'John' }] };
+  const result = processUsers(testData.users);
+  expect(result).toEqual(expected);
+});
+```
+
+### 5. Use Proper DOM Testing
+
+Use testing utilities that handle DOM state properly:
+
+```javascript
+// Instead of manipulating document directly
+document.body.innerHTML = "<div>test</div>";
+
+// Use testing library utilities
+test("should render component", () => {
+  render(<Component />);
+  expect(screen.getByRole("button")).toBeInTheDocument();
+});
+```
+
+### 6. Handle Storage APIs Correctly
+
+Mock storage APIs with proper cleanup:
+
+```javascript
+beforeEach(() => {
+  // Mock localStorage
+  const mockStorage = {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+    clear: jest.fn(),
+  };
+
+  Object.defineProperty(window, "localStorage", {
+    value: mockStorage,
+  });
+});
+```
+
+## Framework-Specific Examples
+
+### Jest
+
+```javascript
+// ❌ Avoid global mutations
+global.API_URL = "http://localhost";
+
+// ✅ Use proper Jest patterns
+beforeAll(() => {
+  process.env.API_URL = "http://localhost";
+});
+
+afterAll(() => {
+  delete process.env.API_URL;
+});
+
+// ✅ Use Jest's environment variables
+// In jest.config.js
+module.exports = {
+  setupFilesAfterEnv: ["<rootDir>/test-setup.js"],
+  testEnvironment: "jsdom",
+};
+```
+
+### Vitest
+
+```javascript
+// ✅ Use Vitest's environment handling
+import { beforeEach, afterEach, vi } from "vitest";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+```
+
+### Cypress
+
+```javascript
+// ❌ Avoid global mutations in test files
+window.localStorage.setItem("token", "fake");
+
+// ✅ Use Cypress commands and hooks
+beforeEach(() => {
+  cy.window().then((win) => {
+    win.localStorage.setItem("token", "fake");
+  });
+});
+
+// ✅ Use Cypress utilities
+cy.clearLocalStorage();
+cy.clearCookies();
+```
+
+### Playwright
+
+```javascript
+// ✅ Use Playwright's context isolation
+test("should work with storage", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("token", "fake");
+  });
+
+  // Test implementation
+});
+```
+
+## Common Global Objects to Avoid Mutating
+
+### Process Environment
+
+```javascript
+// ❌ Avoid
+process.env.NODE_ENV = "production";
+
+// ✅ Better
+beforeEach(() => {
+  originalNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+});
+```
+
+### Window Object
+
+```javascript
+// ❌ Avoid
+window.customProperty = "value";
+
+// ✅ Better
+beforeEach(() => {
+  window.customProperty = "value";
+});
+
+afterEach(() => {
+  delete window.customProperty;
+});
+```
+
+### Document
+
+```javascript
+// ❌ Avoid
+document.title = "Test Page";
+
+// ✅ Better
+beforeEach(() => {
+  originalTitle = document.title;
+  document.title = "Test Page";
+});
+
+afterEach(() => {
+  document.title = originalTitle;
+});
+```
+
+## When Not To Use It
+
+This rule may not be suitable if:
+
+- You're testing global state management specifically
+- Your application architecture requires global state modifications
+- You're testing browser APIs that require global mutations
+- You're using test utilities that handle cleanup automatically
+
+In these cases, you can:
+
+```javascript
+// Disable for specific lines
+// eslint-disable-next-line test-flakiness/no-global-state-mutation
+window.customAPI = mockAPI;
+
+// Disable for test files that specifically test global behavior
+/* eslint-disable test-flakiness/no-global-state-mutation */
+```
+
+## Related Rules
+
+- [no-test-isolation](./no-test-isolation.md) - Prevents test interdependencies
+- [no-random-data](./no-random-data.md) - Prevents non-deterministic test data
+- [no-unconditional-wait](./no-unconditional-wait.md) - Encourages proper test timing
+
+## Further Reading
+
+- [Jest - Setup and Teardown](https://jestjs.io/docs/setup-teardown)
+- [Testing Library - Best Practices](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)
+- [Vitest - Mocking](https://vitest.dev/guide/mocking.html)
+- [Playwright - Test Isolation](https://playwright.dev/docs/browser-contexts)
+- [Clean Code - Test Isolation Principles](https://blog.cleancoder.com/uncle-bob/2017/05/05/TestDefinitions.html)

--- a/examples/no-global-state-mutation-violations.test.js
+++ b/examples/no-global-state-mutation-violations.test.js
@@ -1,0 +1,140 @@
+/**
+ * Examples of no-global-state-mutation rule violations
+ * These patterns should be detected by the eslint-plugin-test-flakiness
+ */
+
+describe('Global State Mutation Violations', () => {
+  // ❌ BAD: Modifying window object
+  it('should not modify window object', () => {
+    window.globalVar = 'test value';
+    window.config = { apiUrl: 'http://test.com' };
+    window.localStorage.setItem('key', 'value');
+    window.sessionStorage.setItem('session', 'data');
+
+    expect(window.globalVar).toBe('test value');
+  });
+
+  // ❌ BAD: Modifying global object (Node.js)
+  it('should not modify global object', () => {
+    global.testConfig = { debug: true };
+    global.mockData = [1, 2, 3];
+    global.setTimeout = jest.fn(); // Modifying global functions
+
+    expect(global.testConfig.debug).toBe(true);
+  });
+
+  // ❌ BAD: Modifying document object
+  it('should not modify document properties', () => {
+    document.title = 'Test Title';
+    document.cookie = 'test=value';
+    document.domain = 'test.com';
+    document.body.className = 'test-class';
+
+    expect(document.title).toBe('Test Title');
+  });
+
+  // ❌ BAD: Modifying process.env
+  it('should not modify process.env', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.API_KEY = 'secret';
+    process.env.DEBUG = 'true';
+
+    expect(process.env.NODE_ENV).toBe('test');
+  });
+
+  // ❌ BAD: Modifying Math object
+  it('should not modify Math object', () => {
+    Math.random = () => 0.5; // Overriding Math.random
+    Math.customMethod = () => 42;
+
+    expect(Math.random()).toBe(0.5);
+  });
+
+  // ❌ BAD: Modifying Date constructor
+  it('should not modify Date', () => {
+    const originalDate = Date;
+    // eslint-disable-next-line no-global-assign
+    Date = jest.fn(() => new originalDate('2020-01-01'));
+    Date.now = () => 1577836800000;
+
+    expect(new Date().getFullYear()).toBe(2020);
+  });
+
+  // ❌ BAD: Modifying Array prototype
+  it('should not modify prototypes', () => {
+    Array.prototype.customMethod = function() {
+      return this.length * 2;
+    };
+
+    Object.prototype.customProp = 'test';
+
+    String.prototype.reverse = function() {
+      return this.split('').reverse().join('');
+    };
+
+    expect([1, 2, 3].customMethod()).toBe(6);
+  });
+
+  // ❌ BAD: Modifying console object
+  it('should not modify console', () => {
+    console.log = jest.fn();
+    console.error = jest.fn();
+    console.warn = () => {};
+
+    console.log('test');
+    expect(console.log).toHaveBeenCalled();
+  });
+
+  // ❌ BAD: Modifying navigator object
+  it('should not modify navigator', () => {
+    // In Node.js test environment, navigator might not exist
+     
+    if (typeof navigator !== 'undefined') {
+      // eslint-disable-next-line no-undef
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Custom User Agent',
+        writable: true
+      });
+
+      // eslint-disable-next-line no-undef
+      navigator.onLine = false;
+
+      // eslint-disable-next-line no-undef
+      expect(navigator.userAgent).toBe('Custom User Agent');
+    }
+  });
+
+  // ❌ BAD: Creating global variables without cleanup
+  it('should not create global variables', () => {
+    globalThis.myGlobalVar = 'test';
+    window.myApp = { initialized: true };
+    global.cache = new Map();
+
+    expect(globalThis.myGlobalVar).toBe('test');
+    // No cleanup - affects other tests!
+  });
+
+  // ❌ BAD: Modifying module-level variables
+  let moduleVariable = 'initial';
+  const moduleConfig = { setting: 'default' };
+
+  it('should not modify module variables', () => {
+    moduleVariable = 'modified';
+    moduleConfig.setting = 'changed';
+    moduleConfig.newProp = 'added';
+
+    expect(moduleVariable).toBe('modified');
+    // These changes persist across tests!
+  });
+
+  // ❌ BAD: Modifying imported modules
+  it('should not modify imported modules', () => {
+    const moment = require('moment');
+    moment.locale('fr'); // Global change
+
+    const lodash = require('lodash');
+    lodash.customFunction = () => 'custom';
+
+    expect(moment.locale()).toBe('fr');
+  });
+});

--- a/lib/rules/no-global-state-mutation.js
+++ b/lib/rules/no-global-state-mutation.js
@@ -1,0 +1,319 @@
+/**
+ * @fileoverview Rule to prevent global state mutations in tests
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const { isTestFile, isInHook } = require('../utils/helpers');
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Prevent global state mutations that can cause test interdependencies',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/tigredonorte/eslint-plugin-test-flakiness/blob/main/docs/rules/no-global-state-mutation.md'
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowInHooks: {
+            type: 'boolean',
+            default: true
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      avoidGlobalMutation: 'Avoid mutating {{object}} in tests. Use beforeEach/afterEach for proper cleanup.',
+      useLocalVariable: 'Use local variables instead of modifying global state.',
+      needsCleanup: '{{storage}} changes need cleanup in afterEach hook.',
+      avoidProcessEnv: 'Modifying process.env can affect other tests. Store original value and restore it.',
+      avoidDocumentMutation: 'Document mutations can affect other tests. Use test-specific containers.'
+    }
+  },
+
+  create(context) {
+    if (!isTestFile(context.getFilename())) {
+      return {};
+    }
+
+    const options = context.options[0] || {};
+    const allowInHooks = options.allowInHooks !== false;
+    const sourceCode = context.getSourceCode();
+
+    function checkGlobalAssignment(node) {
+      if (node.type === 'AssignmentExpression') {
+        const left = node.left;
+
+        // Check for global object mutations
+        if (left.type === 'MemberExpression') {
+          // Check for direct process.env.VARIABLE assignments first (process.env.NODE_ENV = "test")
+          if (isProcessEnvAssignment(left)) {
+            if (!isInHook(node, ['beforeEach', 'afterEach'])) {
+              context.report({
+                node,
+                messageId: 'avoidProcessEnv'
+              });
+            }
+            return; // Don't double-report as avoidGlobalMutation
+          }
+
+          const object = left.object;
+
+          // List of global objects to check
+          const globalObjects = [
+            'global',
+            'window',
+            'document',
+            'process',
+            'console',
+            'localStorage',
+            'sessionStorage',
+            'navigator',
+            'Math',
+            'Date'
+          ];
+
+          if (object.type === 'Identifier' && globalObjects.includes(object.name)) {
+            // Allow in setup/teardown hooks if configured
+            if (allowInHooks && isInHook(node, ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'])) {
+              // Still warn for beforeAll without afterAll cleanup
+              if (isInHook(node, ['beforeAll'])) {
+                context.report({
+                  node,
+                  messageId: 'avoidGlobalMutation',
+                  data: { object: object.name }
+                });
+              }
+              return;
+            }
+
+            // Don't flag process.env assignments here - they're handled separately below
+            if (object.name === 'process' && isProcessEnvAssignment(left)) {
+              return; // Skip general process mutation reporting
+            }
+
+            // Special handling for document mutations
+            if (object.name === 'document') {
+              context.report({
+                node,
+                messageId: 'avoidDocumentMutation'
+              });
+              return;
+            }
+
+            // Special handling for localStorage/sessionStorage property assignment
+            if ((object.name === 'localStorage' || object.name === 'sessionStorage') &&
+                !isInHook(node, ['beforeEach', 'afterEach'])) {
+              context.report({
+                node,
+                messageId: 'needsCleanup',
+                data: { storage: object.name }
+              });
+              return;
+            }
+
+            // Special handling for Math and Date
+            if (object.name === 'Math' || object.name === 'Date') {
+              context.report({
+                node,
+                messageId: 'avoidGlobalMutation',
+                data: { object: object.name }
+              });
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: 'avoidGlobalMutation',
+              data: { object: object.name }
+            });
+          }
+
+          // Check for nested assignments like window.myApp.config = {} or document.body.innerHTML
+          if (object.type === 'MemberExpression') {
+            const rootObject = getRootObject(object);
+            if (rootObject && globalObjects.includes(rootObject.name)) {
+              // Skip process.env assignments - they're handled specifically below
+              if (rootObject.name === 'process' && isProcessEnvAssignment(left)) {
+                return;
+              }
+
+              // Special handling for document properties
+              if (rootObject.name === 'document') {
+                context.report({
+                  node,
+                  messageId: 'avoidDocumentMutation'
+                });
+                return;
+              }
+
+              context.report({
+                node,
+                messageId: 'avoidGlobalMutation',
+                data: { object: rootObject.name }
+              });
+            }
+          }
+
+        }
+      }
+    }
+
+    function getRootObject(memberExpr) {
+      let current = memberExpr;
+      while (current.object && current.object.type === 'MemberExpression') {
+        current = current.object;
+      }
+      return current.object;
+    }
+
+    function isProcessEnvAssignment(left) {
+      // Check if assignment is to process.env.* (left is process.env.VARNAME)
+      return left.type === 'MemberExpression' &&
+             left.object.type === 'MemberExpression' &&
+             left.object.object.type === 'Identifier' &&
+             left.object.object.name === 'process' &&
+             left.object.property.name === 'env';
+    }
+
+    function checkGlobalMethodCalls(node) {
+      if (node.type === 'CallExpression' &&
+          node.callee.type === 'MemberExpression') {
+
+        const obj = node.callee.object;
+        const method = node.callee.property.name;
+
+        // Check for methods that modify global state
+        const dangerousMethods = {
+          'localStorage': ['setItem', 'removeItem', 'clear'],
+          'sessionStorage': ['setItem', 'removeItem', 'clear'],
+          'document': ['write', 'writeln'],
+          'console': ['log', 'error', 'warn'], // Tracked for completeness; these are explicitly allowed and not reported
+          'window': ['addEventListener', 'removeEventListener']
+        };
+
+        if (obj.type === 'Identifier' && dangerousMethods[obj.name]) {
+          if (dangerousMethods[obj.name].includes(method)) {
+            // Allow console calls for debugging (they don't really mutate global state)
+            if (obj.name === 'console') {
+              return;
+            }
+
+            if (!isInHook(node, ['beforeEach', 'afterEach'])) {
+              if (obj.name === 'localStorage' || obj.name === 'sessionStorage') {
+                context.report({
+                  node,
+                  messageId: 'needsCleanup',
+                  data: { storage: obj.name }
+                });
+              } else {
+                context.report({
+                  node,
+                  messageId: 'useLocalVariable'
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    function checkGlobalVariableDeclaration(node) {
+      // Check for global variable declarations without var/let/const
+      if (node.type === 'AssignmentExpression' &&
+          node.left.type === 'Identifier') {
+
+        const varName = node.left.name;
+
+        // Check if this assignment is to a declared variable
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+        const variable = scope.set.get(varName);
+
+        // Allow assignments to declared variables (like testHelper)
+        if (variable || isInHook(node, ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'])) {
+          return;
+        }
+
+        // This creates a global variable
+        context.report({
+          node,
+          messageId: 'useLocalVariable'
+        });
+      }
+    }
+
+    function checkTestOnly(node) {
+      // Check for test.only or it.only (covered by separate rule but impacts global state)
+      if (node.type === 'CallExpression' &&
+          node.callee.type === 'MemberExpression') {
+
+        const obj = node.callee.object;
+        const prop = node.callee.property;
+
+        if ((obj.name === 'test' || obj.name === 'it' || obj.name === 'describe') &&
+            prop.name === 'only') {
+          // This affects global test execution state
+          context.report({
+            node,
+            messageId: 'avoidGlobalMutation',
+            data: { object: 'test execution order' }
+          });
+        }
+      }
+    }
+
+    function checkDeleteOperations(node) {
+      // Check for delete operations on global objects
+      if (node.type === 'UnaryExpression' && node.operator === 'delete') {
+        if (node.argument.type === 'MemberExpression') {
+          const object = node.argument.object;
+
+          const globalObjects = ['global', 'window', 'document', 'process'];
+
+          if (object.type === 'Identifier' && globalObjects.includes(object.name)) {
+            // Allow delete in hooks for cleanup
+            if (allowInHooks && isInHook(node, ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'])) {
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: 'avoidGlobalMutation',
+              data: { object: object.name }
+            });
+          }
+
+          // Check for process.env deletions
+          if (object.type === 'MemberExpression' &&
+              object.object.name === 'process' &&
+              object.property.name === 'env') {
+            context.report({
+              node,
+              messageId: 'avoidProcessEnv'
+            });
+          }
+        }
+      }
+    }
+
+    return {
+      AssignmentExpression(node) {
+        checkGlobalAssignment(node);
+        checkGlobalVariableDeclaration(node);
+      },
+      CallExpression(node) {
+        checkGlobalMethodCalls(node);
+        checkTestOnly(node);
+      },
+      UnaryExpression(node) {
+        checkDeleteOperations(node);
+      }
+    };
+  }
+};

--- a/tests/lib/rules/no-global-state-mutation.test.js
+++ b/tests/lib/rules/no-global-state-mutation.test.js
@@ -1,0 +1,477 @@
+/**
+ * @fileoverview Tests for no-global-state-mutation rule
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/no-global-state-mutation');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
+
+const ruleTester = getRuleTester();
+
+ruleTester.run('no-global-state-mutation', rule, {
+  valid: [
+    // Non-test files should be ignored
+    {
+      code: 'window.globalVar = "value"',
+      filename: 'src/app.js'
+    },
+    {
+      code: 'global.config = {}',
+      filename: 'src/config.js'
+    },
+
+    // Local variables are fine
+    {
+      code: 'const localVar = "value"',
+      filename: 'Local.test.js'
+    },
+    {
+      code: 'let testData = { key: "value" }',
+      filename: 'TestData.test.js'
+    },
+    {
+      code: 'function test() { const x = 1; }',
+      filename: 'Function.test.js'
+    },
+
+    // Reading global state is okay
+    {
+      code: 'const value = window.location.href',
+      filename: 'Read.test.js'
+    },
+    {
+      code: 'if (global.DEBUG) { console.log("debug") }',
+      filename: 'ReadGlobal.test.js'
+    },
+    {
+      code: 'expect(window.innerWidth).toBeGreaterThan(0)',
+      filename: 'Expect.test.js'
+    },
+
+    // Mocking is allowed
+    {
+      code: 'jest.spyOn(window, "alert").mockImplementation(() => {})',
+      filename: 'Mock.test.js'
+    },
+    {
+      code: 'vi.stubGlobal("fetch", mockFetch)',
+      filename: 'Stub.test.js'
+    },
+    {
+      code: 'sinon.stub(global, "setTimeout")',
+      filename: 'Sinon.test.js'
+    },
+
+    // In beforeEach/afterEach for cleanup
+    {
+      code: 'beforeEach(() => { window.testState = {}; })',
+      filename: 'Setup.test.js'
+    },
+    {
+      code: 'afterEach(() => { delete window.testState; })',
+      filename: 'Cleanup.test.js'
+    },
+
+    // localStorage/sessionStorage with proper cleanup
+    {
+      code: 'afterEach(() => { localStorage.clear(); })',
+      filename: 'LocalStorageClear.test.js'
+    },
+    {
+      code: 'beforeEach(() => { sessionStorage.clear(); })',
+      filename: 'SessionStorageClear.test.js'
+    },
+
+    // Module-scoped variables in test files (debatable but often needed)
+    {
+      code: 'let testHelper; beforeEach(() => { testHelper = new TestHelper(); })',
+      filename: 'TestHelper.test.js'
+    },
+
+    // allowInHooks: true (default) - global mutations allowed in hooks
+    {
+      code: 'beforeEach(() => { window.testData = "value"; })',
+      filename: 'HooksAllowed.test.js',
+      options: [{ allowInHooks: true }]
+    },
+    {
+      code: 'afterEach(() => { delete global.testVar; })',
+      filename: 'HooksGlobalDelete.test.js',
+      options: [{ allowInHooks: true }]
+    },
+    {
+      code: 'beforeEach(() => { localStorage.clear(); })',
+      filename: 'HooksLocalStorage.test.js',
+      options: [{ allowInHooks: true }]
+    }
+  ],
+
+  invalid: [
+    // Direct window property mutation
+    {
+      code: 'window.testData = "value"',
+      filename: 'Window.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+    {
+      code: 'window.config = { key: "value" }',
+      filename: 'WindowConfig.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+    {
+      code: 'window.location.href = "http://example.com"',
+      filename: 'WindowLocation.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+
+    // Direct global property mutation
+    {
+      code: 'global.testVar = 123',
+      filename: 'Global.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'global' }
+      }]
+    },
+    {
+      code: 'global.config = {}',
+      filename: 'GlobalConfig.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'global' }
+      }]
+    },
+    {
+      code: 'global.process.env.TEST = "value"',
+      filename: 'GlobalProcess.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'global' }
+      }]
+    },
+
+    // process.env mutations
+    {
+      code: 'process.env.NODE_ENV = "test"',
+      filename: 'ProcessEnv.test.js',
+      errors: [{
+        messageId: 'avoidProcessEnv'
+      }]
+    },
+    {
+      code: 'process.env.API_KEY = "secret"',
+      filename: 'ApiKey.test.js',
+      errors: [{
+        messageId: 'avoidProcessEnv'
+      }]
+    },
+    {
+      code: 'delete process.env.DEBUG',
+      filename: 'DeleteEnv.test.js',
+      errors: [{
+        messageId: 'avoidProcessEnv'
+      }]
+    },
+
+    // localStorage mutations without cleanup
+    {
+      code: 'localStorage.setItem("key", "value")',
+      filename: 'LocalStorage.test.js',
+      errors: [{
+        messageId: 'needsCleanup',
+        data: { storage: 'localStorage' }
+      }]
+    },
+    {
+      code: 'localStorage.removeItem("key")',
+      filename: 'LocalStorageRemove.test.js',
+      errors: [{
+        messageId: 'needsCleanup',
+        data: { storage: 'localStorage' }
+      }]
+    },
+    {
+      code: 'localStorage.key = "value"',
+      filename: 'LocalStorageDirect.test.js',
+      errors: [{
+        messageId: 'needsCleanup',
+        data: { storage: 'localStorage' }
+      }]
+    },
+
+    // sessionStorage mutations without cleanup
+    {
+      code: 'sessionStorage.setItem("key", "value")',
+      filename: 'SessionStorage.test.js',
+      errors: [{
+        messageId: 'needsCleanup',
+        data: { storage: 'sessionStorage' }
+      }]
+    },
+    {
+      code: 'sessionStorage.removeItem("key")',
+      filename: 'SessionStorageRemove.test.js',
+      errors: [{
+        messageId: 'needsCleanup',
+        data: { storage: 'sessionStorage' }
+      }]
+    },
+
+    // document mutations
+    {
+      code: 'document.title = "New Title"',
+      filename: 'DocumentTitle.test.js',
+      errors: [{
+        messageId: 'avoidDocumentMutation'
+      }]
+    },
+    {
+      code: 'document.body.innerHTML = "<div>test</div>"',
+      filename: 'DocumentBody.test.js',
+      errors: [{
+        messageId: 'avoidDocumentMutation'
+      }]
+    },
+    {
+      code: 'document.cookie = "test=value"',
+      filename: 'DocumentCookie.test.js',
+      errors: [{
+        messageId: 'avoidDocumentMutation'
+      }]
+    },
+
+    // Global function overrides
+    {
+      code: 'window.alert = () => {}',
+      filename: 'OverrideAlert.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+    {
+      code: 'console.log = jest.fn()',
+      filename: 'ConsoleOverride.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'console' }
+      }]
+    },
+    {
+      code: 'Math.random = () => 0.5',
+      filename: 'MathOverride.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'Math' }
+      }]
+    },
+    {
+      code: 'Date.now = () => 1234567890',
+      filename: 'DateOverride.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'Date' }
+      }]
+    },
+
+    // Multiple violations
+    {
+      code: `
+        window.testVar = "test";
+        global.config = {};
+        localStorage.setItem("key", "value");
+        process.env.TEST = "1";
+      `,
+      filename: 'Multiple.test.js',
+      errors: [
+        { messageId: 'avoidGlobalMutation', data: { object: 'window' } },
+        { messageId: 'avoidGlobalMutation', data: { object: 'global' } },
+        { messageId: 'needsCleanup', data: { storage: 'localStorage' } },
+        { messageId: 'avoidProcessEnv' }
+      ]
+    },
+
+    // Nested mutations
+    {
+      code: 'window.myApp.config = {}',
+      filename: 'NestedWindow.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+    {
+      code: 'global.myLib.state = "new"',
+      filename: 'NestedGlobal.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'global' }
+      }]
+    },
+
+    // Delete operations
+    {
+      code: 'delete window.myProperty',
+      filename: 'DeleteWindow.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+    {
+      code: 'delete global.myVar',
+      filename: 'DeleteGlobal.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'global' }
+      }]
+    },
+
+    // allowInHooks: false - global mutations not allowed even in hooks
+    {
+      code: 'beforeEach(() => { window.testData = "value"; })',
+      filename: 'HooksNotAllowed.test.js',
+      options: [{ allowInHooks: false }],
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+    {
+      code: 'afterEach(() => { global.config = {}; })',
+      filename: 'HooksGlobalNotAllowed.test.js',
+      options: [{ allowInHooks: false }],
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'global' }
+      }]
+    },
+    {
+      code: 'beforeAll(() => { document.title = "Test"; })',
+      filename: 'HooksDocumentNotAllowed.test.js',
+      options: [{ allowInHooks: false }],
+      errors: [{
+        messageId: 'avoidDocumentMutation'
+      }]
+    },
+    {
+      code: 'afterAll(() => { delete window.customProp; })',
+      filename: 'HooksDeleteNotAllowed.test.js',
+      options: [{ allowInHooks: false }],
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+    {
+      code: 'beforeAll(() => { localStorage.setItem("key", "value"); })',
+      filename: 'HooksStorageNotAllowed.test.js',
+      options: [{ allowInHooks: false }],
+      errors: [{
+        messageId: 'needsCleanup',
+        data: { storage: 'localStorage' }
+      }]
+    },
+
+    // beforeAll hook with global mutation (line 87 coverage)
+    {
+      code: 'beforeAll(() => { window.config = {}; })',
+      filename: 'BeforeAllGlobal.test.js',
+      options: [{ allowInHooks: true }],
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'window' }
+      }]
+    },
+
+    // process.env assignment not to be double-reported (line 98 coverage)
+    {
+      code: 'global.process.env.NODE_ENV = "test"',
+      filename: 'GlobalProcessEnvSpecific.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'global' }
+      }]
+    },
+
+    // Nested global assignment (line 144 coverage)
+    {
+      code: 'global.app.process.env.NODE_ENV = "test"',
+      filename: 'NestedGlobalProcessEnv.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'global' }
+      }]
+    },
+
+    // Global variable creation without declaration (line 244 coverage)
+    {
+      code: 'globalTestVar = "some value"',
+      filename: 'GlobalVarCreation.test.js',
+      errors: [{
+        messageId: 'useLocalVariable'
+      }]
+    },
+
+    // test.only usage (line 262 coverage)
+    {
+      code: 'test.only("should do something", () => {})',
+      filename: 'TestOnly.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'test execution order' }
+      }]
+    },
+
+    // describe.only usage
+    {
+      code: 'describe.only("test suite", () => {})',
+      filename: 'DescribeOnly.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'test execution order' }
+      }]
+    },
+
+    // it.only usage
+    {
+      code: 'it.only("should do something", () => {})',
+      filename: 'ItOnly.test.js',
+      errors: [{
+        messageId: 'avoidGlobalMutation',
+        data: { object: 'test execution order' }
+      }]
+    },
+
+    // Global variable assignment without let/const (covers line 216)
+    {
+      code: 'someGlobalVar = "test"',
+      filename: 'GlobalAssignment.test.js',
+      errors: [{
+        messageId: 'useLocalVariable'
+      }]
+    }
+  ]
+});
+
+// Test rule schema
+describe('no-global-state-mutation schema', () => {
+  it('should have correct schema properties', () => {
+    expect(rule.meta.schema).toHaveLength(1);
+    expect(rule.meta.schema[0].type).toBe('object');
+    expect(rule.meta.schema[0].properties).toHaveProperty('allowInHooks');
+    expect(rule.meta.schema[0].properties.allowInHooks.type).toBe('boolean');
+    expect(rule.meta.schema[0].properties.allowInHooks.default).toBe(true);
+    expect(rule.meta.schema[0].additionalProperties).toBe(false);
+  });
+});


### PR DESCRIPTION
 Existing Behavior

  - No validation for global state mutations in test files
  - Tests could freely modify window, document, process.env, and other global objects without warnings
  - No protection against prototype pollution or global function overrides in tests
  - Test files could create global variables and modify shared state without cleanup requirements

  Intended New Behavior

  - ESLint rule detects and prevents mutations to global objects (window, document, global, process, etc.)
  - Warns against process.env modifications and storage API usage without proper cleanup
  - Identifies prototype modifications and test.only usage that affects global execution state
  - Allows global mutations in setup/teardown hooks when allowInHooks option is enabled

  Dev Checks

  - [Y] Functionality can be toggled on/off
  - [Y] New code is covered by unit/integration tests
  - Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
  - [Y] There is appropriate documentation for the new work
  - Any new environment variables are populated into variable groups for all environments

  Testing Plan / Demo

  1. Install the ESLint plugin and add the rule to your ESLint configuration:
  {
    "rules": {
      "test-flakiness/no-global-state-mutation": "error"
    }
  }
  2. Create a test file with global state mutations:
  // test.spec.js
  test('should fail linting', () => {
    window.globalVar = 'test'; // Should trigger error
    process.env.NODE_ENV = 'development'; // Should trigger error
    localStorage.setItem('key', 'value'); // Should trigger error
  });
  3. Run ESLint on the test file - expect to see error messages for each global mutation
  4. Test the allowInHooks option by adding mutations in beforeEach/afterEach hooks - should not trigger
  errors when allowInHooks is true
  5. Verify the rule ignores non-test files by creating similar mutations in regular source files

  Test Results