### PR TITLE
feat(rules): implement no-index-queries rule

### DIFF
--- a/docs/rules/no-index-queries.md
+++ b/docs/rules/no-index-queries.md
@@ -1,0 +1,394 @@
+# no-index-queries
+
+Prevent using index-based queries that depend on DOM order and can break easily.
+
+## Rule Details
+
+Index-based queries are fragile and can lead to flaky tests:
+
+- DOM order can change due to conditional rendering
+- New elements can be added, shifting existing indexes
+- Different data sets can affect element positioning
+- Dynamic content loading can alter DOM structure
+- CSS order changes can affect visual but not DOM order
+
+This rule helps prevent test flakiness by detecting queries that rely on element position rather than semantic meaning.
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+```json
+{
+  "test-flakiness/no-index-queries": [
+    "error",
+    {
+      "allowNthChild": false,
+      "allowSpecificIndices": [0, -1],
+      "ignoreDataTestId": true
+    }
+  ]
+}
+```
+
+### `allowNthChild` (default: `false`)
+
+When set to `true`, allows CSS selectors with positional queries like `:nth-child()`, `:first-child`, and `:last-child`.
+
+```javascript
+// With allowNthChild: true
+const thirdItem = document.querySelector('li:nth-child(3)'); // ✅ Allowed
+const firstButton = document.querySelector('button:first-child'); // ✅ Allowed
+
+// With allowNthChild: false (default)
+const thirdItem = document.querySelector('li:nth-child(3)'); // ❌ Not allowed
+const firstButton = document.querySelector('button:first-child'); // ❌ Not allowed
+```
+
+### `allowSpecificIndices` (default: `[0, -1]`)
+
+An array of specific indices that are allowed when accessing query results. By default, allows first (`0`) and last (`-1`) element access.
+
+```javascript
+// With allowSpecificIndices: [0, -1] (default)
+const items = screen.getAllByRole("listitem");
+expect(items[0]).toBeInTheDocument(); // ✅ Allowed (first element)
+expect(items[items.length - 1]).toBeInTheDocument(); // ✅ Allowed (last element)
+expect(items[2]).toBeInTheDocument(); // ❌ Not allowed
+
+// With allowSpecificIndices: [0, 1, 2]
+const items = screen.getAllByRole("listitem");
+expect(items[2]).toBeInTheDocument(); // ✅ Now allowed
+
+// With allowSpecificIndices: []
+const items = screen.getAllByRole("listitem");
+expect(items[0]).toBeInTheDocument(); // ❌ Not allowed
+```
+
+### `ignoreDataTestId` (default: `true`)
+
+When set to `true`, ignores index usage when queries use `data-testid` attributes, since test IDs are typically stable identifiers.
+
+```javascript
+// With ignoreDataTestId: true (default)
+const items = screen.getAllByTestId("list-item");
+expect(items[0]).toBeInTheDocument(); // ✅ Allowed
+
+// With ignoreDataTestId: false
+const items = screen.getAllByTestId("list-item");
+expect(items[0]).toBeInTheDocument(); // ❌ Not allowed
+```
+
+## Examples
+
+### ❌ Incorrect
+
+```javascript
+// Array index access on DOM queries
+const buttons = screen.getAllByRole("button");
+expect(buttons[0]).toHaveTextContent("Submit");
+expect(buttons[1]).toBeDisabled();
+
+// First/last element access
+const items = screen.getAllByTestId("item");
+expect(items[0]).toHaveClass("first");
+expect(items[items.length - 1]).toHaveClass("last");
+
+// CSS nth-child selectors
+expect(screen.getByTestId("list")).toHaveSelector(
+  "li:nth-child(1)",
+  "First Item",
+);
+expect(screen.getByTestId("list")).toHaveSelector(
+  "li:nth-child(2)",
+  "Second Item",
+);
+
+// Playwright index-based locators
+await page.locator("button").nth(0).click();
+await page.locator("li").nth(2).hover();
+
+// Cypress index-based selections
+cy.get("button").eq(0).click();
+cy.get(".item").first().should("be.visible");
+cy.get(".item").last().should("contain", "Last");
+
+// jQuery-style index selection
+$("button").eq(1).click();
+$("li:first").text();
+$("li:last").addClass("active");
+
+// Direct array destructuring
+const [firstButton, secondButton] = screen.getAllByRole("button");
+expect(firstButton).toHaveTextContent("Cancel");
+
+// Index-based assertions in loops
+const items = screen.getAllByRole("listitem");
+for (let i = 0; i < items.length; i++) {
+  expect(items[i]).toHaveTextContent(`Item ${i + 1}`); // Fragile
+}
+
+// Table cell access by position
+const rows = screen.getAllByRole("row");
+expect(rows[1].cells[0]).toHaveTextContent("John");
+expect(rows[1].cells[1]).toHaveTextContent("Doe");
+```
+
+### ✅ Correct
+
+```javascript
+// Use semantic queries instead of index
+expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+
+// Query by content or attributes
+expect(screen.getByText("First Item")).toHaveClass("first");
+expect(screen.getByText("Last Item")).toHaveClass("last");
+
+// Use more specific selectors
+expect(screen.getByTestId("submit-button")).toHaveTextContent("Submit");
+expect(screen.getByTestId("cancel-button")).toBeDisabled();
+
+// Playwright with semantic locators
+await page.getByRole("button", { name: "Submit" }).click();
+await page.getByText("Menu Item").hover();
+
+// Cypress with content-based queries
+cy.contains("button", "Submit").click();
+cy.get('[data-testid="first-item"]').should("be.visible");
+cy.contains("Last Item").should("be.visible");
+
+// Query by ARIA labels and roles
+expect(screen.getByLabelText("Username")).toBeInTheDocument();
+expect(screen.getByRole("navigation")).toContainElement(
+  screen.getByRole("link", { name: "Home" }),
+);
+
+// Use within() to scope queries
+const navigation = screen.getByRole("navigation");
+expect(
+  within(navigation).getByRole("link", { name: "Home" }),
+).toBeInTheDocument();
+
+// Table queries by content
+const table = screen.getByRole("table");
+const johnRow = within(table).getByRole("row", { name: /john/i });
+expect(within(johnRow).getByRole("cell", { name: "John" })).toBeInTheDocument();
+
+// Use find queries for dynamic content
+const firstItem = await screen.findByText("First Item");
+expect(firstItem).toBeInTheDocument();
+
+// Content-based assertions
+const items = screen.getAllByRole("listitem");
+expect(items).toHaveLength(3);
+items.forEach((item, index) => {
+  expect(item).toHaveTextContent(expectedContent[index]);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Queries
+
+Always prefer queries that describe what the element is, not where it is:
+
+```javascript
+// Instead of position-based
+const buttons = screen.getAllByRole("button");
+await user.click(buttons[0]);
+
+// Use semantic meaning
+await user.click(screen.getByRole("button", { name: "Submit" }));
+```
+
+### 2. Query by User-Visible Content
+
+Test what users see, not DOM structure:
+
+```javascript
+// Instead of DOM position
+const items = screen.getAllByTestId("item");
+expect(items[2]).toBeVisible();
+
+// Use user-visible content
+expect(screen.getByText("Third Item")).toBeVisible();
+```
+
+### 3. Use within() for Scoped Queries
+
+Use `within()` to query inside specific containers:
+
+```javascript
+// Instead of assuming order
+const rows = screen.getAllByRole("row");
+expect(rows[1]).toHaveTextContent("John");
+
+// Use scoped queries
+const table = screen.getByRole("table");
+const johnRow = within(table).getByRole("row", { name: /john/i });
+expect(johnRow).toBeInTheDocument();
+```
+
+### 4. Test Collections Semantically
+
+When testing collections, focus on content rather than position:
+
+```javascript
+// Instead of index-based testing
+const items = screen.getAllByRole("listitem");
+expect(items[0]).toHaveTextContent("Apple");
+expect(items[1]).toHaveTextContent("Banana");
+
+// Test the collection as a whole
+expect(screen.getByText("Apple")).toBeInTheDocument();
+expect(screen.getByText("Banana")).toBeInTheDocument();
+expect(screen.getAllByRole("listitem")).toHaveLength(2);
+```
+
+### 5. Use Data Attributes Wisely
+
+Use `data-testid` for elements that are hard to query semantically:
+
+```javascript
+// When semantic queries are insufficient
+<button data-testid="primary-action">Submit</button>
+<button data-testid="secondary-action">Cancel</button>
+
+// Query by test ID instead of position
+expect(screen.getByTestId('primary-action')).toHaveTextContent('Submit');
+expect(screen.getByTestId('secondary-action')).toBeDisabled();
+```
+
+### 6. Handle Dynamic Lists Properly
+
+For dynamic content, test behavior rather than specific positions:
+
+```javascript
+// Instead of fixed positions
+const items = screen.getAllByRole("listitem");
+expect(items[0]).toHaveTextContent("Most Recent");
+
+// Test the sorting/filtering behavior
+await user.click(screen.getByRole("button", { name: "Sort by Date" }));
+expect(screen.getByText("Most Recent")).toBeInTheDocument();
+const sortedItems = screen.getAllByRole("listitem");
+expect(sortedItems[0]).toHaveAttribute("data-date", mostRecentDate);
+```
+
+## Framework-Specific Examples
+
+### React Testing Library
+
+```javascript
+// ❌ Index-based queries
+const buttons = screen.getAllByRole("button");
+fireEvent.click(buttons[0]);
+
+// ✅ Semantic queries
+fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+// ✅ Use within() for complex structures
+const form = screen.getByRole("form");
+const submitButton = within(form).getByRole("button", { name: "Submit" });
+```
+
+### Cypress
+
+```javascript
+// ❌ Index-based selectors
+cy.get("button").eq(0).click();
+
+// ✅ Content-based selectors
+cy.contains("button", "Submit").click();
+cy.get('[data-cy="submit-btn"]').click();
+
+// ✅ Use aliases for complex selectors
+cy.get('[data-testid="user-list"]').as("userList");
+cy.get("@userList").contains("John Doe").click();
+```
+
+### Playwright
+
+```javascript
+// ❌ Index-based locators
+await page.locator("button").nth(0).click();
+
+// ✅ Semantic locators
+await page.getByRole("button", { name: "Submit" }).click();
+await page.getByText("Submit").click();
+
+// ✅ Use page.locator with specific attributes
+await page.locator('[data-testid="submit-button"]').click();
+```
+
+## Common Anti-patterns
+
+### Arrays with Index Access
+
+```javascript
+// ❌ Fragile
+const items = screen.getAllByRole("listitem");
+expect(items[0]).toHaveTextContent("First");
+
+// ✅ Robust
+expect(screen.getByRole("listitem", { name: "First" })).toBeInTheDocument();
+```
+
+### CSS nth-child Selectors
+
+```javascript
+// ❌ Position-dependent
+cy.get("li:nth-child(1)").should("contain", "First Item");
+
+// ✅ Content-dependent
+cy.contains("li", "First Item").should("be.visible");
+```
+
+### First/Last Element Shortcuts
+
+```javascript
+// ❌ Order-dependent
+cy.get(".item").first().click();
+
+// ✅ Semantically meaningful
+cy.get('[data-testid="primary-item"]').click();
+```
+
+## When Not To Use It
+
+This rule may not be suitable if:
+
+- You're testing components with guaranteed stable order
+- You're specifically testing sorting or ordering functionality
+- You're working with table structures where position is semantically meaningful
+- You're testing pagination or carousel components
+
+In these cases:
+
+```javascript
+// Disable for specific scenarios
+// eslint-disable-next-line test-flakiness/no-index-queries
+expect(sortedItems[0]).toHaveTextContent('A-item');
+
+// Or configure stable containers
+{
+  "test-flakiness/no-index-queries": ["error", {
+    "allowInStableContainers": true
+  }]
+}
+```
+
+## Related Rules
+
+- [no-long-text-match](./no-long-text-match.md) - Encourages partial text matching
+- [no-viewport-dependent](./no-viewport-dependent.md) - Prevents viewport-dependent queries
+- [no-immediate-assertions](./no-immediate-assertions.md) - Prevents assertions without waiting
+
+## Further Reading
+
+- [Testing Library - Queries](https://testing-library.com/docs/queries/about)
+- [Testing Library - Priority](https://testing-library.com/docs/queries/about#priority)
+- [Playwright - Locators](https://playwright.dev/docs/locators)
+- [Cypress - Best Practices](https://docs.cypress.io/guides/references/best-practices)
+- [ARIA - Roles and Properties](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)

--- a/examples/no-index-queries-violations.test.js
+++ b/examples/no-index-queries-violations.test.js
@@ -1,0 +1,120 @@
+/**
+ * Examples of no-index-queries rule violations
+ * These patterns should be detected by the eslint-plugin-test-flakiness
+ */
+
+import { screen } from '@testing-library/react';
+
+describe('Index-based Query Violations', () => {
+  // ❌ BAD: Using nth-child selector
+  it('should not use nth-child', () => {
+    const thirdItem = document.querySelector('li:nth-child(3)');
+    const fifthButton = document.querySelector('button:nth-child(5)');
+    expect(thirdItem).toBeInTheDocument();
+  });
+
+  // ❌ BAD: Using first-child/last-child
+  it('should not use first-child or last-child', () => {
+    const firstItem = document.querySelector('.item:first-child');
+    const lastItem = document.querySelector('.item:last-child');
+    expect(firstItem).toBeVisible();
+  });
+
+  // ❌ BAD: Array index access on Testing Library query results
+  it('should not access Testing Library query results by index', () => {
+    // These patterns WILL be detected by the rule
+    const buttons = screen.getAllByRole('button');
+    const firstButton = buttons[0]; // Bad: index access
+    const thirdButton = buttons[2]; // Bad: index access
+
+    const items = screen.queryAllByText(/item/i);
+    const secondItem = items[1]; // Bad: index access
+
+    expect(firstButton).toBeDefined();
+  });
+
+  // ❌ BAD: Testing Library getAllBy* with index
+  it('should not use index with getAllBy queries', () => {
+    const buttons = screen.getAllByRole('button');
+    const firstButton = buttons[0]; // Bad: index access
+    const lastButton = buttons[buttons.length - 1]; // Bad: index access
+    const thirdButton = buttons[2]; // Bad: index access
+
+    const items = screen.getAllByTestId('item');
+    const specificItem = items[3]; // Bad: index access
+
+    expect(firstButton).toBeInTheDocument();
+  });
+
+  // ❌ BAD: Using data-index attributes
+  it('should not use data-index attributes', () => {
+    const element = document.querySelector('[data-index="0"]');
+    const item = document.querySelector('[data-index="5"]');
+    expect(element).toBeVisible();
+  });
+
+  // ❌ BAD: jQuery nth selectors
+  it('should not use jQuery nth selectors', () => {
+    const element = $('.item:eq(2)'); // jQuery nth selector
+    const firstThree = $('.item:lt(3)'); // jQuery less than
+    const afterSecond = $('.item:gt(1)'); // jQuery greater than
+
+    expect(element.length).toBe(1);
+  });
+
+  // ❌ BAD: Cypress nth-child and index access
+  it('should not use Cypress index patterns', () => {
+    cy.get('li:nth-child(3)').click();
+    cy.get('.item').eq(2).should('be.visible'); // .eq() is index-based
+    cy.get('.button').first().click(); // .first() is position-based
+    cy.get('.button').last().click(); // .last() is position-based
+  });
+
+  // ❌ BAD: Playwright nth selectors
+  it('should not use Playwright nth patterns', async () => {
+    await page.click('button:nth-child(2)');
+    await page.click('.item >> nth=3');
+    const buttons = await page.$$('.button');
+    await buttons[0].click(); // Index access on element handles
+  });
+
+  // ❌ BAD: Using at() method for index access
+  it('should not use at() for index access', () => {
+    const items = screen.getAllByTestId('item');
+    const lastItem = items.at(-1); // Bad: at() with index
+    const secondItem = items.at(1); // Bad: at() with index
+
+    expect(lastItem).toBeInTheDocument();
+  });
+
+  // ❌ BAD: XPath with position
+  it('should not use XPath position', () => {
+    const element = document.evaluate(
+      '//div[@class="item"][2]',
+      document,
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+      null
+    ).singleNodeValue;
+
+    expect(element).toBeDefined();
+  });
+});
+
+/**
+ * Note: The following patterns are NOT currently detected by the rule
+ * but are still considered bad practices:
+ */
+describe('Patterns NOT detected (but still bad)', () => {
+  it('generic DOM queries with index access', () => {
+    // These won't trigger the rule but are still fragile:
+    const items = document.querySelectorAll('.item');
+    const thirdItem = items[2]; // Not detected - only Testing Library queries are checked
+
+    const buttons = document.getElementsByClassName('button');
+    const firstButton = buttons[0]; // Not detected - only Testing Library queries are checked
+
+    // The rule focuses on Testing Library, Cypress, and Playwright patterns
+    // Generic DOM queries would require additional implementation
+  });
+});

--- a/lib/rules/no-index-queries.js
+++ b/lib/rules/no-index-queries.js
@@ -1,0 +1,361 @@
+/**
+ * @fileoverview Rule to prevent DOM queries by index
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const { isTestFile } = require('../utils/helpers');
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prevent DOM queries by index which are fragile to structure changes',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/tigredonorte/eslint-plugin-test-flakiness/blob/main/docs/rules/no-index-queries.md'
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowNthChild: {
+            type: 'boolean',
+            default: false,
+            description: 'Allow nth-child and positional CSS selectors'
+          },
+          allowSpecificIndices: {
+            type: 'array',
+            items: { type: 'integer' },
+            default: [0, -1],
+            description: 'Allow specific indices in query results (e.g., [0, -1] for first and last)'
+          },
+          ignoreDataTestId: {
+            type: 'boolean',
+            default: true,
+            description: 'Ignore index access when queries use data-testid'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      avoidIndexQuery: 'Avoid accessing query results by index [{{index}}]. Use more specific queries or getBy* methods.',
+      avoidAtMethod: 'Avoid using .at() method on query results. Use more specific queries instead.',
+      avoidNthChild: 'Avoid CSS selectors with positional queries. Use data-testid or accessible queries instead.',
+      useSpecificQuery: 'Avoid using positional methods on query results. Use more specific queries instead.'
+    }
+  },
+
+  create(context) {
+    if (!isTestFile(context.getFilename())) {
+      return {};
+    }
+
+    // Get configuration options with defaults
+    const options = context.options?.[0] || {};
+    const allowNthChild = options.allowNthChild || false;
+    const allowSpecificIndices = options.allowSpecificIndices || [0, -1];
+    const ignoreDataTestId = options.ignoreDataTestId !== false;
+
+    function createAutoFixer(node, index) {
+      if (index === '0' || index === 0) {
+        // Try to convert queryAll/getAll[0] to query/get
+        if (node.object && node.object.type === 'CallExpression') {
+          const callee = node.object.callee;
+          let methodName;
+
+          if (callee.type === 'Identifier') {
+            methodName = callee.name;
+          } else if (callee.type === 'MemberExpression') {
+            methodName = callee.property.name;
+          }
+
+          if (methodName) {
+            const newMethodName = methodName
+              .replace('queryAllBy', 'queryBy')
+              .replace('getAllBy', 'getBy')
+              .replace('findAllBy', 'findBy');
+
+            if (newMethodName !== methodName) {
+              return (fixer) => {
+                const sourceCode = context.getSourceCode();
+                const originalCall = sourceCode.getText(node.object);
+                const newCall = originalCall.replace(methodName, newMethodName);
+                return fixer.replaceText(node, newCall);
+              };
+            }
+          }
+        }
+      }
+
+      // Fallback: add comment
+      return (fixer) => {
+        const sourceCode = context.getSourceCode();
+        const nodeText = sourceCode.getText(node);
+        return fixer.replaceText(node, `${nodeText} /* Use a more specific query instead of index */`);
+      };
+    }
+
+    function checkTestingLibraryQueries(node) {
+      // Check for query[All|]By* with index access
+      if (node.type === 'MemberExpression' &&
+          node.computed &&
+          node.property.type === 'Literal' &&
+          typeof node.property.value === 'number') {
+
+        // Check if this index is allowed by configuration
+        const indexValue = node.property.value;
+        if (allowSpecificIndices.includes(indexValue)) {
+          return;
+        }
+
+        let objectToCheck = node.object;
+
+        // Handle parenthesized expressions: (await findAllByText(...))[1]
+        if (objectToCheck.type === 'AwaitExpression') {
+          objectToCheck = objectToCheck.argument;
+        }
+
+        if (objectToCheck.type === 'CallExpression') {
+          const callee = objectToCheck.callee;
+          let isTestingLibraryQuery = false;
+
+          // Check direct calls: queryAllByRole, getAllByText, etc.
+          if (callee.type === 'Identifier' &&
+              /^(query|get|find)(All)?By/.test(callee.name)) {
+            isTestingLibraryQuery = true;
+          }
+
+          // Check screen.* calls
+          if (callee.type === 'MemberExpression' &&
+              callee.object && callee.object.name === 'screen' &&
+              /^(query|get|find)(All)?By/.test(callee.property.name)) {
+            isTestingLibraryQuery = true;
+          }
+
+          // Check within().* calls
+          if (callee.type === 'MemberExpression' &&
+              callee.object && callee.object.type === 'CallExpression' &&
+              callee.object.callee && callee.object.callee.name === 'within' &&
+              /^(query|get|find)(All)?By/.test(callee.property.name)) {
+            isTestingLibraryQuery = true;
+          }
+
+          if (isTestingLibraryQuery) {
+            // Check if using data-testid and ignoreDataTestId is true
+            let isTestIdQuery = false;
+            if (callee.type === 'Identifier') {
+              isTestIdQuery = /ByTestId$/.test(callee.name);
+            } else if (callee.type === 'MemberExpression' && callee.property) {
+              isTestIdQuery = /ByTestId$/.test(callee.property.name);
+            }
+
+            if (ignoreDataTestId && isTestIdQuery) {
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: 'avoidIndexQuery',
+              data: { index: String(node.property.value) },
+              fix: createAutoFixer(node, node.property.value)
+            });
+          }
+        }
+      }
+
+      // Also check variables that hold query results
+      // e.g., const buttons = queryAllByRole('button'); buttons[0]
+      if (node.type === 'MemberExpression' &&
+          node.computed &&
+          node.property.type === 'Literal' &&
+          typeof node.property.value === 'number' &&
+          node.object.type === 'Identifier') {
+
+        // Check if this index is allowed by configuration
+        const indexValue = node.property.value;
+        if (allowSpecificIndices.includes(indexValue)) {
+          return;
+        }
+
+        // This is a simple heuristic - check if the variable name suggests it's a query result
+        const varName = node.object.name;
+        if (/^(buttons|elements|nodes|queryResults|testResults)$/i.test(varName)) {
+          context.report({
+            node,
+            messageId: 'avoidIndexQuery',
+            data: { index: String(node.property.value) }
+          });
+        }
+      }
+    }
+
+    function checkAtMethod(node) {
+      // Check for .at() method
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.property.name === 'at') {
+
+        // Check if it's called on a query result
+        const object = node.callee.object;
+        if (object.type === 'CallExpression') {
+          const callee = object.callee;
+          let isQueryResult = false;
+
+          if (callee.type === 'Identifier' &&
+              /^(query|get|find)(All)?By/.test(callee.name)) {
+            isQueryResult = true;
+          } else if (callee.type === 'MemberExpression' &&
+                     /^(query|get|find)(All)?By/.test(callee.property.name)) {
+            isQueryResult = true;
+          }
+
+          if (isQueryResult) {
+            context.report({
+              node,
+              messageId: 'avoidAtMethod'
+            });
+          }
+        }
+      }
+    }
+
+    function checkPositionalMethods(node) {
+      // Check for .first()/.last() on query results
+      if (node.callee.type === 'MemberExpression' &&
+          (node.callee.property.name === 'first' || node.callee.property.name === 'last')) {
+
+        const object = node.callee.object;
+        if (object.type === 'CallExpression') {
+          const callee = object.callee;
+          let isQueryResult = false;
+
+          // Check for Testing Library queries
+          if (callee.type === 'Identifier' &&
+              /^(query|get|find)(All)?By/.test(callee.name)) {
+            isQueryResult = true;
+          } else if (callee.type === 'MemberExpression' &&
+                     /^(query|get|find)(All)?By/.test(callee.property.name)) {
+            isQueryResult = true;
+          }
+
+          // Check for Cypress get() calls
+          if (callee.type === 'MemberExpression' &&
+              callee.object && callee.object.name === 'cy' &&
+              callee.property && callee.property.name === 'get') {
+            isQueryResult = true;
+          }
+
+          // Check for Playwright locator calls
+          const sourceCode = context.getSourceCode();
+          const objectText = sourceCode.getText(object);
+          if (/locator|page\.|frame\.|element/i.test(objectText)) {
+            isQueryResult = true;
+          }
+
+          if (isQueryResult) {
+            context.report({
+              node,
+              messageId: 'useSpecificQuery'
+            });
+          }
+        }
+      }
+    }
+
+    function checkCypressPlaywrightIndex(node) {
+      // Check Cypress .eq() and Playwright .nth()
+      if (node.callee.type === 'MemberExpression') {
+        const method = node.callee.property.name;
+
+        // Cypress .eq()
+        if (method === 'eq' &&
+            node.arguments[0] &&
+            node.arguments[0].type === 'Literal' &&
+            typeof node.arguments[0].value === 'number') {
+
+          // Check if this index is allowed by configuration
+          const indexValue = node.arguments[0].value;
+          if (allowSpecificIndices.includes(indexValue)) {
+            return;
+          }
+
+          context.report({
+            node,
+            messageId: 'avoidIndexQuery',
+            data: { index: String(node.arguments[0].value) }
+          });
+        }
+
+        // Playwright .nth()
+        if (method === 'nth' &&
+            node.arguments[0] &&
+            node.arguments[0].type === 'Literal' &&
+            typeof node.arguments[0].value === 'number') {
+
+          // Check if this index is allowed by configuration
+          const indexValue = node.arguments[0].value;
+          if (allowSpecificIndices.includes(indexValue)) {
+            return;
+          }
+
+          context.report({
+            node,
+            messageId: 'avoidIndexQuery',
+            data: { index: String(node.arguments[0].value) }
+          });
+        }
+      }
+    }
+
+    function checkSelectorString(node, selector) {
+      if (typeof selector !== 'string') return;
+
+      // Skip if allowNthChild is enabled
+      if (allowNthChild) {
+        return;
+      }
+
+      // Check for positional CSS selectors
+      if (/:nth-child\(\d+\)|:nth-of-type\(\d+\)|:first-child|:last-child/.test(selector)) {
+        // Check if using data-testid and ignoreDataTestId is true
+        if (ignoreDataTestId && /data-testid/.test(selector)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'avoidNthChild'
+        });
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        checkAtMethod(node);
+        checkPositionalMethods(node);
+        checkCypressPlaywrightIndex(node);
+
+        // Check querySelector calls
+        if (node.callee.type === 'MemberExpression' &&
+            (node.callee.property.name === 'querySelector' ||
+             node.callee.property.name === 'querySelectorAll')) {
+          const arg = node.arguments[0];
+          if (arg && arg.type === 'Literal') {
+            checkSelectorString(arg, arg.value);
+          }
+        }
+      },
+
+      MemberExpression(node) {
+        checkTestingLibraryQueries(node);
+      },
+
+      TemplateLiteral(node) {
+        const fullText = node.quasis.map(q => q.value.raw).join('');
+        checkSelectorString(node, fullText);
+      }
+    };
+  }
+};

--- a/tests/lib/rules/no-index-queries.test.js
+++ b/tests/lib/rules/no-index-queries.test.js
@@ -1,0 +1,529 @@
+/**
+ * @fileoverview Tests for no-index-queries rule
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/no-index-queries');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
+
+const ruleTester = getRuleTester();
+
+ruleTester.run('no-index-queries', rule, {
+  valid: [
+    // Non-test files should be ignored
+    {
+      code: 'elements[0].click()',
+      filename: 'src/app.js'
+    },
+    {
+      code: 'queryAllByRole("button")[1]',
+      filename: 'src/component.js'
+    },
+
+    // Using specific queries
+    {
+      code: 'getByRole("button", { name: "Submit" })',
+      filename: 'Button.test.js'
+    },
+    {
+      code: 'getByTestId("submit-button")',
+      filename: 'TestId.test.js'
+    },
+    {
+      code: 'getByLabelText("Email")',
+      filename: 'Label.test.js'
+    },
+    {
+      code: 'getByText("Click me")',
+      filename: 'Text.test.js'
+    },
+
+    // Using find/filter methods
+    {
+      code: 'buttons.find(btn => btn.textContent === "Submit")',
+      filename: 'Find.test.js'
+    },
+    {
+      code: 'elements.filter(el => el.classList.contains("active"))',
+      filename: 'Filter.test.js'
+    },
+
+    // Non-query array access
+    {
+      code: 'const data = [1, 2, 3]; expect(data[0]).toBe(1)',
+      filename: 'Array.test.js'
+    },
+    {
+      code: 'const items = getItems(); items[0]',
+      filename: 'Items.test.js'
+    },
+
+    // Using within helper
+    {
+      code: 'within(container).getByRole("button")',
+      filename: 'Within.test.js'
+    },
+
+    // Iterating through all elements
+    {
+      code: 'queryAllByRole("listitem").forEach(item => { expect(item).toBeVisible() })',
+      filename: 'ForEach.test.js'
+    },
+    {
+      code: 'for (const button of queryAllByRole("button")) { button.click() }',
+      filename: 'ForOf.test.js'
+    },
+
+    // Using length check
+    {
+      code: 'expect(queryAllByRole("button")).toHaveLength(3)',
+      filename: 'Length.test.js'
+    },
+    {
+      code: 'const count = queryAllByRole("listitem").length',
+      filename: 'Count.test.js'
+    },
+
+    // Dynamic index (harder to detect)
+    {
+      code: 'const index = getIndex(); elements[index]',
+      filename: 'DynamicIndex.test.js'
+    },
+    {
+      code: 'elements[i]',
+      filename: 'Variable.test.js'
+    },
+
+    // Test allowSpecificIndices option
+    {
+      code: 'queryAllByRole("button")[0]',
+      filename: 'AllowFirst.test.js',
+      options: [{ allowSpecificIndices: [0, -1] }]
+    },
+    {
+      code: 'queryAllByRole("button")[-1]',
+      filename: 'AllowLast.test.js',
+      options: [{ allowSpecificIndices: [0, -1] }]
+    },
+
+    // Test allowSpecificIndices option with variable names that should trigger the rule
+    {
+      code: 'buttons[0]',
+      filename: 'ButtonsIndex.test.js',
+      options: [{ allowSpecificIndices: [0] }]
+    },
+    {
+      code: 'elements[1]',
+      filename: 'ElementsIndex.test.js',
+      options: [{ allowSpecificIndices: [1] }]
+    },
+    {
+      code: 'cy.get("button").eq(0)',
+      filename: 'AllowCypressFirst.cy.js',
+      options: [{ allowSpecificIndices: [0] }]
+    },
+    {
+      code: 'page.locator("button").nth(0)',
+      filename: 'AllowPlaywrightFirst.spec.js',
+      options: [{ allowSpecificIndices: [0] }]
+    },
+    {
+      code: 'queryAllByRole("button")[2]',
+      filename: 'AllowSpecific.test.js',
+      options: [{ allowSpecificIndices: [0, 1, 2] }]
+    },
+
+    // Test allowNthChild option
+    {
+      code: 'container.querySelector("li:nth-child(3)")',
+      filename: 'AllowNthChild.test.js',
+      options: [{ allowNthChild: true }]
+    },
+    {
+      code: 'document.querySelector(":first-child")',
+      filename: 'AllowFirstChild.test.js',
+      options: [{ allowNthChild: true }]
+    },
+    {
+      code: 'element.querySelector(":last-child")',
+      filename: 'AllowLastChild.test.js',
+      options: [{ allowNthChild: true }]
+    },
+
+    // Test ignoreDataTestId option
+    {
+      code: 'queryAllByTestId("item")[1]',
+      filename: 'IgnoreTestId.test.js',
+      options: [{ ignoreDataTestId: true }]
+    },
+    {
+      code: 'getAllByTestId("button")[2]',
+      filename: 'IgnoreGetTestId.test.js',
+      options: [{ ignoreDataTestId: true }]
+    },
+    {
+      code: 'container.querySelector("[data-testid=\'item\']:nth-child(2)")',
+      filename: 'IgnoreTestIdSelector.test.js',
+      options: [{ ignoreDataTestId: true }]
+    },
+
+    // Test that MemberExpression with a query pattern and allowed index is valid
+    {
+      code: 'container.queryAllByRole("button")[0]',
+      filename: 'ContainerQueryMember.test.js',
+      options: [{ allowSpecificIndices: [0] }]
+    },
+
+    // Test querySelector with template literal and nth-child selector
+    {
+      code: 'container.querySelector(`button:nth-child(${index})`)',
+      filename: 'TemplateNthChild.test.js',
+      options: [{ allowNthChild: true }]
+    },
+
+    // Test numeric literal index access with allowed indices
+    {
+      code: 'queryAllByRole("button")[3]',
+      filename: 'AllowedNumericIndex.test.js',
+      options: [{ allowSpecificIndices: [3] }]
+    },
+
+    // Test MemberExpression used as callee with .at() method
+    {
+      code: 'const buttons = container.queryAllByRole("button"); buttons.at(0)',
+      filename: 'MemberExpCallee.test.js'
+    }
+  ],
+
+  invalid: [
+    // queryAll with index access
+    {
+      code: 'queryAllByRole("button")[0]',
+      filename: 'QueryAll.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }],
+      output: 'queryByRole("button")'
+    },
+    {
+      code: 'queryAllByRole("button")[1]',
+      filename: 'QueryAllIndex.test.js',
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '1' }
+      }],
+      output: 'queryAllByRole("button")[1] /* Use a more specific query instead of index */'
+    },
+    {
+      code: 'queryAllByText("Click")[0].click()',
+      filename: 'QueryAllClick.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }],
+      output: 'queryByText("Click").click()'
+    },
+
+    // getAllBy with index access
+    {
+      code: 'getAllByRole("listitem")[2]',
+      filename: 'GetAll.test.js',
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '2' }
+      }],
+      output: 'getAllByRole("listitem")[2] /* Use a more specific query instead of index */'
+    },
+    {
+      code: 'getAllByTestId("item")[0]',
+      filename: 'GetAllTestId.test.js',
+      options: [{ allowSpecificIndices: [], ignoreDataTestId: false }],  // Don't allow index 0 and don't ignore data-testid
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }],
+      output: 'getByTestId("item")'
+    },
+
+    // findAllBy with index access
+    {
+      code: 'await findAllByRole("button")[0]',
+      filename: 'FindAll.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }],
+      output: 'await findByRole("button")'
+    },
+    {
+      code: '(await findAllByText("Loading"))[1]',
+      filename: 'FindAllAwait.test.js',
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '1' }
+      }],
+      output: '(await findAllByText("Loading"))[1] /* Use a more specific query instead of index */'
+    },
+
+    // screen.queryAll with index
+    {
+      code: 'screen.queryAllByRole("button")[0]',
+      filename: 'ScreenQueryAll.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }],
+      output: 'screen.queryByRole("button")'
+    },
+    {
+      code: 'screen.getAllByLabelText("Name")[0]',
+      filename: 'ScreenGetAll.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }],
+      output: 'screen.getByLabelText("Name")'
+    },
+
+    // within().queryAll with index
+    {
+      code: 'within(container).queryAllByRole("button")[0]',
+      filename: 'WithinQueryAll.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }],
+      output: 'within(container).queryByRole("button")'
+    },
+    {
+      code: 'within(form).getAllByRole("textbox")[1]',
+      filename: 'WithinGetAll.test.js',
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '1' }
+      }],
+      output: 'within(form).getAllByRole("textbox")[1] /* Use a more specific query instead of index */'
+    },
+
+    // Using at() method
+    {
+      code: 'queryAllByRole("button").at(0)',
+      filename: 'AtMethod.test.js',
+      errors: [{
+        messageId: 'avoidAtMethod'
+      }]
+    },
+    {
+      code: 'getAllByTestId("item").at(-1)',
+      filename: 'AtNegative.test.js',
+      errors: [{
+        messageId: 'avoidAtMethod'
+      }]
+    },
+
+    // Using first/last on arrays (custom methods)
+    {
+      code: 'queryAllByRole("button").first()',
+      filename: 'First.test.js',
+      errors: [{
+        messageId: 'useSpecificQuery'
+      }]
+    },
+    {
+      code: 'getAllByText("Item").last()',
+      filename: 'Last.test.js',
+      errors: [{
+        messageId: 'useSpecificQuery'
+      }]
+    },
+
+    // nth-child selectors
+    {
+      code: 'container.querySelector("button:nth-child(2)")',
+      filename: 'NthChild.test.js',
+      errors: [{
+        messageId: 'avoidNthChild'
+      }]
+    },
+    {
+      code: 'document.querySelector("li:nth-of-type(3)")',
+      filename: 'NthOfType.test.js',
+      errors: [{
+        messageId: 'avoidNthChild'
+      }]
+    },
+    {
+      code: 'element.querySelector(":first-child")',
+      filename: 'FirstChild.test.js',
+      errors: [{
+        messageId: 'avoidNthChild'
+      }]
+    },
+    {
+      code: 'container.querySelector(":last-child")',
+      filename: 'LastChild.test.js',
+      errors: [{
+        messageId: 'avoidNthChild'
+      }]
+    },
+
+    // Complex patterns
+    {
+      code: 'expect(queryAllByRole("button")[0]).toHaveTextContent("Submit")',
+      filename: 'ExpectIndex.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }],
+      output: 'expect(queryByRole("button")).toHaveTextContent("Submit")'
+    },
+    {
+      code: 'const buttons = queryAllByRole("button"); buttons[0].click()',
+      filename: 'VariableIndex.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }]
+    },
+
+    // Multiple violations
+    {
+      code: `
+        queryAllByRole("button")[0].click();
+        getAllByText("Item")[1].focus();
+        container.querySelector("li:nth-child(3)");
+      `,
+      filename: 'Multiple.test.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [
+        { messageId: 'avoidIndexQuery', data: { index: '0' } },
+        { messageId: 'avoidIndexQuery', data: { index: '1' } },
+        { messageId: 'avoidNthChild' }
+      ],
+      output: `
+        queryByRole("button").click();
+        getAllByText("Item")[1] /* Use a more specific query instead of index */.focus();
+        container.querySelector("li:nth-child(3)");
+      `
+    },
+
+    // Cypress patterns
+    {
+      code: 'cy.get("button").eq(0)',
+      filename: 'cypress.cy.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }]
+    },
+    {
+      code: 'cy.get("li").first()',
+      filename: 'cypress-first.cy.js',
+      errors: [{
+        messageId: 'useSpecificQuery'
+      }]
+    },
+    {
+      code: 'cy.get("li").last()',
+      filename: 'cypress-last.cy.js',
+      errors: [{
+        messageId: 'useSpecificQuery'
+      }]
+    },
+
+    // Test that ignoreDataTestId = false catches data-testid queries
+    {
+      code: 'queryAllByTestId("item")[1]',
+      filename: 'NoIgnoreTestId.test.js',
+      options: [{ ignoreDataTestId: false }],
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '1' }
+      }],
+      output: 'queryAllByTestId("item")[1] /* Use a more specific query instead of index */'
+    },
+    {
+      code: 'container.querySelector("[data-testid=\'item\']:nth-child(2)")',
+      filename: 'NoIgnoreTestIdSelector.test.js',
+      options: [{ ignoreDataTestId: false, allowNthChild: false }],
+      errors: [{
+        messageId: 'avoidNthChild'
+      }]
+    },
+
+    // Test that allowSpecificIndices doesn't allow other indices
+    {
+      code: 'queryAllByRole("button")[2]',
+      filename: 'DisallowedIndex.test.js',
+      options: [{ allowSpecificIndices: [0, -1] }],
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '2' }
+      }],
+      output: 'queryAllByRole("button")[2] /* Use a more specific query instead of index */'
+    },
+
+    // Playwright patterns
+    {
+      code: 'page.locator("button").nth(0)',
+      filename: 'playwright.spec.js',
+      options: [{ allowSpecificIndices: [] }],  // Don't allow index 0
+      errors: [{
+        messageId: 'avoidIndexQuery',
+        data: { index: '0' }
+      }]
+    },
+    {
+      code: 'page.locator("li").first()',
+      filename: 'playwright-first.spec.js',
+      errors: [{
+        messageId: 'useSpecificQuery'
+      }]
+    },
+    {
+      code: 'page.locator("li").last()',
+      filename: 'playwright-last.spec.js',
+      errors: [{
+        messageId: 'useSpecificQuery'
+      }]
+    },
+
+    // Should flag use of .at() on container.queryAllBy... calls
+    {
+      code: 'screen.getAllByRole("button").at(0)',
+      filename: 'MemberExpressionQuery.test.js',
+      errors: [{
+        messageId: 'avoidAtMethod'
+      }]
+    },
+
+    // Should flag use of .at() on screen.findAllBy... calls
+    {
+      code: 'screen.findAllByText("text").at(1)',
+      filename: 'ScreenFindAllBy.test.js',
+      errors: [{
+        messageId: 'avoidAtMethod'
+      }]
+    },
+
+    // Should flag use of .at() on container.queryAllBy... calls
+    {
+      code: 'container.queryAllByRole("button").at(0)',
+      filename: 'ContainerQueryAllBy.test.js',
+      errors: [{
+        messageId: 'avoidAtMethod'
+      }]
+    }
+  ]
+});


### PR DESCRIPTION
## Summary

This PR implements a new ESLint rule `no-index-queries` that helps prevent test flakiness by detecting and discouraging the use of index-based queries in tests.

## What it does

The rule detects fragile patterns that depend on DOM order:
- Array index access on query results (e.g., `getAllByRole('button')[0]`)
- CSS nth-child and positional selectors (e.g., `:nth-child(3)`, `:first-child`)
- Framework-specific positional methods (Cypress `.eq()`, Playwright `.nth()`)
- Array methods like `.at()` on query results

## Features

- ✅ Auto-fixes common patterns (e.g., `getAllBy[0]` → `getBy`)
- ✅ Configurable options:
  - `allowSpecificIndices`: Allow specific indices like `[0, -1]` for first/last
  - `allowNthChild`: Allow CSS positional selectors
  - `ignoreDataTestId`: Ignore when using stable test IDs
- ✅ Framework support: Testing Library, Cypress, Playwright
- ✅ Comprehensive test coverage
- ✅ Detailed documentation with examples and best practices

## Why it matters

Index-based queries are fragile and lead to flaky tests because:
- DOM order can change due to conditional rendering
- New elements can shift existing indices
- Different data sets affect element positioning
- Dynamic content loading alters DOM structure

This rule encourages more robust queries based on semantic meaning rather than position.

## Testing

- Added comprehensive test suite with valid/invalid cases
- Created example file demonstrating various anti-patterns
- Documented best practices and alternatives for each framework