### PR TITLE
feat: implement no-unconditional-wait rule to prevent test flakiness

### DIFF
--- a/docs/rules/no-unconditional-wait.md
+++ b/docs/rules/no-unconditional-wait.md
@@ -1,0 +1,470 @@
+# no-unconditional-wait
+
+Prevent unconditional waits (timeouts) that can make tests slow and unreliable.
+
+## Rule Details
+
+Unconditional waits using fixed timeouts are problematic in tests:
+
+- They make tests unnecessarily slow
+- They may be too short on slower systems, causing flakiness
+- They may be too long on faster systems, wasting time
+- They don't adapt to actual conditions
+- They can mask real timing issues
+
+This rule helps prevent test flakiness by detecting unconditional waits and encouraging conditional waiting patterns.
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+```json
+{
+  "test-flakiness/no-unconditional-wait": [
+    "error",
+    {
+      "maxTimeout": 1000,
+      "allowInSetup": true,
+      "allowedMethods": []
+    }
+  ]
+}
+```
+
+### `maxTimeout` (default: `1000`)
+
+Maximum allowed timeout duration in milliseconds.
+
+```javascript
+// With maxTimeout: 1000 (default)
+setTimeout(() => {}, 500); // ✅ Allowed
+setTimeout(() => {}, 2000); // ❌ Too long
+
+// With maxTimeout: 2000
+setTimeout(() => {}, 1500); // ✅ Allowed
+```
+
+### `allowInSetup` (default: `true`)
+
+When set to `true`, allows unconditional waits in setup/teardown hooks.
+
+```javascript
+// With allowInSetup: true (default)
+beforeEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1000)); // ✅ Allowed
+});
+
+// With allowInSetup: false
+beforeEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1000)); // ❌ Not allowed
+});
+```
+
+### `allowedMethods` (default: `[]`)
+
+Array of method names that are allowed to use unconditional waits.
+
+```javascript
+// With allowedMethods: ["debounceWait"]
+await debounceWait(500); // ✅ Allowed
+
+// With allowedMethods: []
+await debounceWait(500); // ❌ Not allowed if it uses setTimeout
+```
+
+## Examples
+
+### ❌ Incorrect
+
+```javascript
+// setTimeout and setInterval
+setTimeout(() => {
+  expect(element).toBeVisible();
+}, 1000);
+
+await new Promise((resolve) => setTimeout(resolve, 2000));
+
+// Page/browser waits
+await page.waitForTimeout(3000);
+await browser.pause(1500);
+
+// Cypress waits
+cy.wait(2000);
+cy.get("button").wait(1000).click();
+
+// Sleep functions
+await sleep(1000);
+await delay(2000);
+
+// Manual promise delays
+await new Promise((resolve) => {
+  setTimeout(resolve, 1000);
+});
+
+// Testing Library with fixed timeout
+await waitFor(
+  () => {
+    expect(element).toBeVisible();
+  },
+  { timeout: 5000 },
+); // Large timeout without condition
+
+// Playwright with long waits
+await page.waitForLoadState("networkidle", { timeout: 10000 });
+
+// Jest fake timers with long advances
+jest.advanceTimersByTime(5000);
+
+// Custom wait functions
+function waitForSeconds(seconds) {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+}
+await waitForSeconds(3);
+
+// Polling with fixed intervals
+while (true) {
+  if (condition()) break;
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+// Animation waits
+await new Promise((resolve) => setTimeout(resolve, 500)); // Wait for animation
+```
+
+### ✅ Correct
+
+```javascript
+// Use conditional waiting
+await waitFor(() => {
+  expect(element).toBeVisible();
+});
+
+// Wait for specific conditions
+await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+
+// Use proper async utilities
+const result = await screen.findByRole("button");
+
+// Page waits for specific conditions
+await page.waitForSelector(".loaded");
+await page.waitForLoadState("networkidle");
+
+// Cypress conditional waits
+cy.get('[data-cy="loading"]').should("not.exist");
+cy.get('[data-cy="content"]').should("be.visible");
+
+// Wait for network requests
+cy.intercept("GET", "/api/data").as("getData");
+cy.wait("@getData");
+
+// Use event-based waiting
+await new Promise((resolve) => {
+  element.addEventListener("transitionend", resolve, { once: true });
+});
+
+// Testing Library with reasonable timeouts and conditions
+await waitFor(
+  () => {
+    expect(element).toHaveClass("loaded");
+  },
+  { timeout: 2000, interval: 50 },
+);
+
+// Playwright with specific conditions
+await page.waitForFunction(() => {
+  return document.querySelector(".spinner") === null;
+});
+
+// Jest fake timers with specific advances
+jest.advanceTimersToNextTimer();
+jest.runOnlyPendingTimers();
+
+// Custom conditional wait functions
+async function waitForCondition(condition, timeout = 2000) {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeout) {
+    if (await condition()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("Condition not met");
+}
+
+// Efficient polling with early exit
+const result = await waitForCondition(async () => {
+  const element = document.querySelector(".target");
+  return element && element.textContent === "Ready";
+});
+
+// Use AbortController for cancellable operations
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 5000);
+
+try {
+  await fetch("/api/data", { signal: controller.signal });
+} catch (error) {
+  if (error.name === "AbortError") {
+    // Handle timeout
+  }
+}
+```
+
+## Best Practices
+
+### 1. Use Conditional Waiting
+
+Replace fixed timeouts with condition-based waiting:
+
+```javascript
+// Instead of fixed timeout
+await new Promise((resolve) => setTimeout(resolve, 1000));
+expect(element).toBeVisible();
+
+// Use conditional waiting
+await waitFor(() => {
+  expect(element).toBeVisible();
+});
+```
+
+### 2. Wait for Specific Events
+
+Wait for meaningful events rather than arbitrary time:
+
+```javascript
+// Instead of timeout
+setTimeout(() => {
+  expect(animation).toHaveClass("completed");
+}, 500);
+
+// Wait for animation event
+await new Promise((resolve) => {
+  element.addEventListener("animationend", resolve, { once: true });
+});
+expect(element).toHaveClass("completed");
+```
+
+### 3. Use Framework Utilities
+
+Leverage built-in waiting utilities:
+
+```javascript
+// Instead of manual timeout
+await new Promise((resolve) => setTimeout(resolve, 1000));
+const button = document.querySelector("button");
+
+// Use Testing Library
+const button = await screen.findByRole("button");
+
+// Use Cypress built-in waiting
+cy.get("button").should("be.visible");
+
+// Use Playwright auto-waiting
+await page.click("button");
+```
+
+### 4. Implement Smart Polling
+
+Create efficient polling mechanisms:
+
+```javascript
+// Instead of fixed interval polling
+while (true) {
+  if (condition()) break;
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+// Smart polling with exponential backoff
+async function pollWithBackoff(condition, maxWait = 5000) {
+  let delay = 10;
+  const start = Date.now();
+
+  while (Date.now() - start < maxWait) {
+    if (await condition()) return true;
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    delay = Math.min(delay * 1.5, 500); // Cap at 500ms
+  }
+
+  throw new Error("Polling timeout");
+}
+```
+
+### 5. Use Proper Timeouts
+
+When timeouts are necessary, make them reasonable:
+
+```javascript
+// Instead of very long timeouts
+await waitFor(
+  () => {
+    expect(element).toBeVisible();
+  },
+  { timeout: 10000 },
+);
+
+// Use reasonable timeouts with clear purpose
+await waitFor(
+  () => {
+    expect(element).toBeVisible();
+  },
+  {
+    timeout: 2000, // Reasonable for UI updates
+    interval: 50, // Fast polling
+  },
+);
+```
+
+### 6. Handle Different Environments
+
+Make timeouts environment-aware:
+
+```javascript
+// Instead of fixed timeout
+const TIMEOUT = 5000;
+
+// Environment-aware timeout
+const TIMEOUT = process.env.CI ? 10000 : 2000;
+
+// Or use adaptive timeouts
+const getTimeout = () => {
+  if (process.env.CI) return 5000;
+  if (process.env.NODE_ENV === "development") return 1000;
+  return 2000;
+};
+```
+
+## Framework-Specific Examples
+
+### React Testing Library
+
+```javascript
+// ❌ Fixed timeout
+setTimeout(() => {
+  expect(screen.getByText("Loaded")).toBeInTheDocument();
+}, 1000);
+
+// ✅ Conditional waiting
+await waitFor(() => {
+  expect(screen.getByText("Loaded")).toBeInTheDocument();
+});
+
+// ✅ findBy queries
+const element = await screen.findByText("Loaded");
+```
+
+### Cypress
+
+```javascript
+// ❌ Fixed wait
+cy.wait(2000);
+cy.get(".content").should("be.visible");
+
+// ✅ Conditional waiting
+cy.get(".loading").should("not.exist");
+cy.get(".content").should("be.visible");
+
+// ✅ Network waiting
+cy.intercept("GET", "/api/data").as("loadData");
+cy.wait("@loadData");
+```
+
+### Playwright
+
+```javascript
+// ❌ Fixed timeout
+await page.waitForTimeout(3000);
+await expect(page.locator(".modal")).toBeVisible();
+
+// ✅ Conditional waiting
+await page.waitForSelector(".modal");
+await expect(page.locator(".modal")).toBeVisible();
+
+// ✅ Wait for specific state
+await page.waitForLoadState("networkidle");
+```
+
+### Jest
+
+```javascript
+// ❌ Large timer advances
+jest.advanceTimersByTime(10000);
+
+// ✅ Advance to next timer
+jest.advanceTimersToNextTimer();
+jest.runOnlyPendingTimers();
+
+// ✅ Flush all timers
+jest.runAllTimers();
+```
+
+## Common Timeout Anti-patterns
+
+### Magic Numbers
+
+```javascript
+// ❌ Unexplained timeout
+await new Promise((resolve) => setTimeout(resolve, 1337));
+
+// ✅ Named constant with explanation
+const DEBOUNCE_DELAY = 300; // Wait for user to stop typing
+await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_DELAY));
+```
+
+### Excessive Timeouts
+
+```javascript
+// ❌ Way too long
+cy.get(".button", { timeout: 30000 }).click();
+
+// ✅ Reasonable timeout
+cy.get(".button", { timeout: 5000 }).click();
+```
+
+### No Timeout Strategy
+
+```javascript
+// ❌ No clear reason for wait
+await page.waitForTimeout(2000);
+await page.click("button");
+
+// ✅ Wait for specific condition
+await page.waitForSelector("button:not(:disabled)");
+await page.click("button");
+```
+
+## When Not To Use It
+
+This rule may not be suitable if:
+
+- You're testing timing-dependent behavior specifically
+- You need to wait for external systems with known delays
+- You're working with animations that have fixed durations
+- You're testing debounced or throttled functionality
+
+In these cases:
+
+```javascript
+// Disable for legitimate timing tests
+// eslint-disable-next-line test-flakiness/no-unconditional-wait
+await new Promise(resolve => setTimeout(resolve, 1000));
+
+// Or configure higher timeout limits
+{
+  "test-flakiness/no-unconditional-wait": ["error", {
+    "maxTimeout": 5000,
+    "allowInSetup": true
+  }]
+}
+```
+
+## Related Rules
+
+- [no-immediate-assertions](./no-immediate-assertions.md) - Requires proper waiting before assertions
+- [no-animation-wait](./no-animation-wait.md) - Prevents animation-specific waits
+- [await-async-events](./await-async-events.md) - Ensures proper async handling
+
+## Further Reading
+
+- [Testing Library - Async Utilities](https://testing-library.com/docs/dom-testing-library/api-async)
+- [Cypress - Best Practices](https://docs.cypress.io/guides/references/best-practices#Unnecessary-Waiting)
+- [Playwright - Auto-waiting](https://playwright.dev/docs/actionability)
+- [Jest - Timer Mocks](https://jestjs.io/docs/timer-mocks)
+- [Effective Test Waiting Strategies](https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning)

--- a/examples/no-unconditional-wait-violations.test.js
+++ b/examples/no-unconditional-wait-violations.test.js
@@ -1,0 +1,103 @@
+/**
+ * Examples of no-unconditional-wait rule violations
+ * These patterns should be detected by the eslint-plugin-test-flakiness
+ */
+
+describe('Unconditional Wait Violations', () => {
+  // ❌ BAD: Cypress wait with fixed number
+  it('should not use cy.wait with number', () => {
+    cy.visit('/page');
+    cy.wait('@apiCall'); // TODO: Replace with actual alias or remove wait; // Bad: unconditional wait
+    cy.get('.content').should('be.visible');
+  });
+
+  // ❌ BAD: waitFor with empty callback
+  it('should not use waitFor without assertions', async () => {
+    await waitFor(() => {
+      // Empty callback - no assertions!
+    });
+
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  // ❌ BAD: waitFor with only console.log
+  it('should not use waitFor without real assertions', async () => {
+    await waitFor(() => {
+      console.log('waiting...');
+      // No assertions, just logging
+    });
+  });
+
+  // ❌ BAD: Playwright waitForTimeout
+  it('should not use page.waitForTimeout', async () => {
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector; // Bad: unconditional wait
+    await page.click('#button');
+  });
+
+  // ❌ BAD: WebdriverIO browser.pause
+  it('should not use browser.pause', () => {
+    browser.url('/page');
+    browser.waitUntil(() => element.isDisplayed()); // TODO: Add condition; // Bad: unconditional wait
+    browser.click('#button');
+  });
+
+  // ❌ BAD: Selenium driver.sleep
+  it('should not use driver.sleep', async () => {
+    await driver.get('/page');
+    await driver.wait(until.elementLocated(By.id('element'))); // TODO: Add condition; // Bad: unconditional wait
+    await driver.findElement(By.id('button')).click();
+  });
+
+  // ❌ BAD: Generic sleep/delay/wait/pause functions
+  it('should not use generic wait functions', async () => {
+    await sleep(2000); // Bad: unconditional wait
+    await delay(1500); // Bad: unconditional wait
+    await wait(3000); // Bad: unconditional wait
+    await pause(1000); // Bad: unconditional wait
+
+    expect(true).toBe(true);
+  });
+
+  // ❌ BAD: Thread.sleep (Java-style)
+  it('should not use Thread.sleep pattern', () => {
+    Thread.sleep(2000); // Bad: unconditional wait
+    expect(element).toBeVisible();
+  });
+
+  // ❌ BAD: setTimeout as unconditional wait
+  it('should not use setTimeout without condition', (done) => {
+    await waitFor(async () => {
+  // Just waiting, no real condition
+      done();
+}, { timeout: 2000 });
+  });
+
+  // ❌ BAD: setInterval without clear condition
+  it('should not use setInterval unconditionally', () => {
+    setInterval(() => {
+      console.log('polling...');
+      // No clear exit condition
+    }, 1000);
+  });
+
+  // ❌ BAD: Promise with only setTimeout
+  it('should not use Promise with just setTimeout', async () => {
+    await waitFor(() => expect(true).toBe(true), { timeout: 2000 });
+    // This is just an unconditional wait
+    expect(screen.getByText('Loaded')).toBeInTheDocument();
+  });
+
+  // ❌ BAD: frame.waitForTimeout in Playwright
+  it('should not use frame.waitForTimeout', async () => {
+    const frame = page.mainFrame();
+    await frame.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector; // Bad: unconditional wait
+    await frame.click('#button');
+  });
+
+  // ❌ BAD: context.waitForTimeout in Playwright
+  it('should not use context.waitForTimeout', async () => {
+    await context.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector; // Bad: unconditional wait
+    await page.click('#button');
+  });
+});

--- a/examples/no-unconditional-wait-violations.test.js
+++ b/examples/no-unconditional-wait-violations.test.js
@@ -1,13 +1,19 @@
+ 
+/* eslint-disable test-flakiness/no-hard-coded-timeout */
+/* eslint-disable no-undef */
+
 /**
  * Examples of no-unconditional-wait rule violations
  * These patterns should be detected by the eslint-plugin-test-flakiness
+ *
+ * Note: ESLint rules are disabled in this file to demonstrate the violations
  */
 
 describe('Unconditional Wait Violations', () => {
   // ❌ BAD: Cypress wait with fixed number
   it('should not use cy.wait with number', () => {
     cy.visit('/page');
-    cy.wait('@apiCall'); // TODO: Replace with actual alias or remove wait; // Bad: unconditional wait
+    cy.wait(5000); // Bad: unconditional wait
     cy.get('.content').should('be.visible');
   });
 
@@ -31,21 +37,21 @@ describe('Unconditional Wait Violations', () => {
   // ❌ BAD: Playwright waitForTimeout
   it('should not use page.waitForTimeout', async () => {
     await page.goto('/');
-    await page.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector; // Bad: unconditional wait
+    await page.waitForTimeout(3000); // Bad: unconditional wait
     await page.click('#button');
   });
 
   // ❌ BAD: WebdriverIO browser.pause
   it('should not use browser.pause', () => {
     browser.url('/page');
-    browser.waitUntil(() => element.isDisplayed()); // TODO: Add condition; // Bad: unconditional wait
+    browser.pause(2000); // Bad: unconditional wait
     browser.click('#button');
   });
 
   // ❌ BAD: Selenium driver.sleep
   it('should not use driver.sleep', async () => {
     await driver.get('/page');
-    await driver.wait(until.elementLocated(By.id('element'))); // TODO: Add condition; // Bad: unconditional wait
+    await driver.sleep(1500); // Bad: unconditional wait
     await driver.findElement(By.id('button')).click();
   });
 
@@ -67,10 +73,10 @@ describe('Unconditional Wait Violations', () => {
 
   // ❌ BAD: setTimeout as unconditional wait
   it('should not use setTimeout without condition', (done) => {
-    await waitFor(async () => {
-  // Just waiting, no real condition
+    setTimeout(() => {
+      // Just waiting, no real condition
       done();
-}, { timeout: 2000 });
+    }, 2000); // Bad: unconditional wait
   });
 
   // ❌ BAD: setInterval without clear condition
@@ -83,7 +89,7 @@ describe('Unconditional Wait Violations', () => {
 
   // ❌ BAD: Promise with only setTimeout
   it('should not use Promise with just setTimeout', async () => {
-    await waitFor(() => expect(true).toBe(true), { timeout: 2000 });
+    await new Promise(resolve => setTimeout(resolve, 1000)); // Bad: unconditional wait
     // This is just an unconditional wait
     expect(screen.getByText('Loaded')).toBeInTheDocument();
   });
@@ -91,13 +97,13 @@ describe('Unconditional Wait Violations', () => {
   // ❌ BAD: frame.waitForTimeout in Playwright
   it('should not use frame.waitForTimeout', async () => {
     const frame = page.mainFrame();
-    await frame.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector; // Bad: unconditional wait
+    await frame.waitForTimeout(2000); // Bad: unconditional wait
     await frame.click('#button');
   });
 
   // ❌ BAD: context.waitForTimeout in Playwright
   it('should not use context.waitForTimeout', async () => {
-    await context.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector; // Bad: unconditional wait
+    await context.waitForTimeout(1000); // Bad: unconditional wait
     await page.click('#button');
   });
 });

--- a/lib/rules/no-unconditional-wait.js
+++ b/lib/rules/no-unconditional-wait.js
@@ -1,0 +1,562 @@
+/**
+ * @fileoverview Rule to prevent unconditional waits in tests
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const { isTestFile, isInMockContext } = require('../utils/helpers');
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow unconditional waits that don\'t wait for specific conditions',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/tigredonorte/eslint-plugin-test-flakiness/blob/main/docs/rules/no-unconditional-wait.md'
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          maxTimeout: {
+            type: 'number',
+            default: 1000,
+            description: 'Maximum allowed timeout duration in milliseconds'
+          },
+          allowInSetup: {
+            type: 'boolean',
+            default: true,
+            description: 'Allow unconditional waits in setup/teardown hooks'
+          },
+          allowedMethods: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+            description: 'Array of method names that are allowed to use unconditional waits'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      avoidUnconditionalWait: 'Avoid unconditional wait. Wait for specific conditions instead.',
+      useWaitFor: 'Use waitFor() with an assertion instead of fixed delay.',
+      useDataTestId: 'Wait for specific elements or conditions instead of arbitrary delays.',
+      exceedsMaxTimeout: 'Timeout of {{timeout}}ms exceeds maximum allowed timeout of {{maxTimeout}}ms.'
+    }
+  },
+
+  create(context) {
+    if (!isTestFile(context.getFilename())) {
+      return {};
+    }
+
+    // Get configuration options - only apply maxTimeout if explicitly configured
+    const options = context.options ? (context.options[0] || {}) : {};
+    const maxTimeout = options.maxTimeout;  // undefined means no limit
+    const allowInSetup = options.allowInSetup !== undefined ? options.allowInSetup : true;
+    const allowedMethods = options.allowedMethods || [];
+
+    // Helper function to check if we're in a setup/teardown hook
+    function isInSetupHook(node) {
+      if (!allowInSetup) return false;
+
+      let parent = node.parent;
+      while (parent) {
+        if (parent.type === 'CallExpression' && parent.callee) {
+          const calleeName = parent.callee.type === 'Identifier'
+            ? parent.callee.name
+            : parent.callee.type === 'MemberExpression' && parent.callee.property
+              ? parent.callee.property.name
+              : null;
+
+          if (calleeName) {
+            const setupHooks = [
+              'beforeAll', 'beforeEach', 'afterAll', 'afterEach',
+              'before', 'beforeEach', 'after', 'afterEach',
+              'setup', 'teardown', 'setupTest', 'teardownTest',
+              'beforeHook', 'afterHook'
+            ];
+            if (setupHooks.includes(calleeName)) {
+              return true;
+            }
+          }
+        }
+        parent = parent.parent;
+      }
+      return false;
+    }
+
+    // Helper function to check if a method is in the allowed list
+    function isAllowedMethod(node) {
+      if (allowedMethods.length === 0) return false;
+
+      let methodName = null;
+      if (node.callee.type === 'Identifier') {
+        methodName = node.callee.name;
+      } else if (node.callee.type === 'MemberExpression' && node.callee.property) {
+        methodName = node.callee.property.name;
+      }
+
+      return methodName && allowedMethods.includes(methodName);
+    }
+
+    // Helper function to check if timeout exceeds max
+    function checkTimeoutValue(node, timeout) {
+      if (maxTimeout && timeout > maxTimeout) {
+        context.report({
+          node,
+          messageId: 'exceedsMaxTimeout',
+          data: {
+            timeout,
+            maxTimeout
+          }
+        });
+        return true;
+      }
+      return false;
+    }
+
+    function checkWaitWithoutCondition(node) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for cy.wait(number) without alias
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.object.name === 'cy' &&
+          node.callee.property.name === 'wait') {
+
+        const arg = node.arguments[0];
+        if (arg && arg.type === 'Literal' && typeof arg.value === 'number') {
+          // Check if timeout exceeds max
+          if (checkTimeoutValue(node, arg.value)) return;
+
+          // Skip the regular error if in setup hook and allowed
+          if (isInSetupHook(node)) return;
+
+          context.report({
+            node,
+            messageId: 'avoidUnconditionalWait',
+            fix(fixer) {
+              // Check if there's already a semicolon after the node
+              const sourceCode = context.getSourceCode();
+              const hasSemicolon = sourceCode.text[node.range[1]] === ';';
+              const replacement = hasSemicolon
+                ? 'cy.wait(\'@apiCall\') // TODO: Replace with actual alias or remove wait'
+                : 'cy.wait(\'@apiCall\') // TODO: Replace with actual alias or remove wait;';
+
+              return fixer.replaceText(node, replacement);
+            }
+          });
+        }
+      }
+    }
+
+    function checkSetTimeout(node) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for setTimeout with fixed delays
+      if (node.callee.name === 'setTimeout' ||
+          (node.callee.type === 'MemberExpression' &&
+           node.callee.property.name === 'setTimeout')) {
+
+        if (!isInMockContext(node, context)) {
+          // Check timeout value if it's a literal
+          const timeoutArg = node.arguments[1];
+          if (timeoutArg && timeoutArg.type === 'Literal' && typeof timeoutArg.value === 'number') {
+            if (checkTimeoutValue(node, timeoutArg.value)) return;
+          }
+
+          // Skip the regular error if in setup hook and allowed
+          if (isInSetupHook(node)) return;
+          // Check if it's part of a polling pattern or Promise constructor
+          let parent = node.parent;
+          while (parent) {
+            const sourceCode = context.getSourceCode();
+            const parentText = sourceCode.getText(parent);
+            // If it's part of a conditional check or polling, it's valid
+            if (/if\s*\(.*\)|check|poll|retry|clearInterval/.test(parentText)) {
+              return;
+            }
+            // Check if it's within a Promise constructor - let Promise checker handle it
+            if (parent.type === 'NewExpression' && parent.callee && parent.callee.name === 'Promise') {
+              return;
+            }
+            // Don't traverse too far up, but continue past ArrowFunctionExpression
+            // in case it's a Promise constructor callback
+            if (parent.type === 'FunctionDeclaration' ||
+                parent.type === 'FunctionExpression') {
+              break;
+            }
+            // Only break on ArrowFunctionExpression if we've already checked a few parents
+            if (parent.type === 'ArrowFunctionExpression' && parent.parent) {
+              // Check if the parent of ArrowFunction is Promise constructor
+              const grandParent = parent.parent;
+              if (grandParent.type === 'NewExpression' && grandParent.callee && grandParent.callee.name === 'Promise') {
+                return;
+              }
+              // Otherwise break here
+              break;
+            }
+            parent = parent.parent;
+          }
+
+          context.report({
+            node,
+            messageId: 'useWaitFor'
+          });
+        }
+      }
+    }
+
+    function checkSetInterval(node) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for setInterval without clear condition
+      if (node.callee.name === 'setInterval') {
+        if (!isInMockContext(node, context)) {
+          // Check interval value if it's a literal
+          const intervalArg = node.arguments[1];
+          if (intervalArg && intervalArg.type === 'Literal' && typeof intervalArg.value === 'number') {
+            if (checkTimeoutValue(node, intervalArg.value)) return;
+          }
+
+          // Skip the regular error if in setup hook and allowed
+          if (isInSetupHook(node)) return;
+          // Check if the callback has a condition to clear the interval
+          const callback = node.arguments[0];
+          if (callback) {
+            const sourceCode = context.getSourceCode();
+            const callbackText = sourceCode.getText(callback);
+            // If it contains clearInterval or a condition, it's likely valid
+            if (/clearInterval|if\s*\(/.test(callbackText)) {
+              return;
+            }
+          }
+          context.report({
+            node,
+            messageId: 'useDataTestId'
+          });
+        }
+      }
+    }
+
+    function checkPromiseWithTimeout(node, awaitNode) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for new Promise with only setTimeout
+      if (node.type === 'NewExpression' && node.callee.name === 'Promise') {
+        const arg = node.arguments[0];
+        if (arg && arg.type === 'ArrowFunctionExpression') {
+          const body = arg.body;
+
+          // Check if body is just setTimeout
+          if (body.type === 'CallExpression' &&
+              body.callee.name === 'setTimeout') {
+
+            // Check if it's a simple timeout (resolve => setTimeout(resolve, n))
+            const setTimeoutFirstArg = body.arguments[0];
+            const timeoutValue = body.arguments[1];
+
+            // Check timeout value if it's a literal
+            if (timeoutValue && timeoutValue.type === 'Literal' && typeof timeoutValue.value === 'number') {
+              if (checkTimeoutValue(node, timeoutValue.value)) return;
+            }
+
+            if (setTimeoutFirstArg &&
+                setTimeoutFirstArg.type === 'Identifier' &&
+                arg.params[0] &&
+                arg.params[0].type === 'Identifier' &&
+                setTimeoutFirstArg.name === arg.params[0].name) {
+
+              // Skip the regular error if in setup hook and allowed
+              if (isInSetupHook(node)) return;
+
+              context.report({
+                node,
+                messageId: 'useWaitFor',
+                fix(fixer) {
+                  const targetNode = awaitNode || node;
+                  const sourceCode = context.getSourceCode();
+                  const hasSemicolon = sourceCode.text[targetNode.range[1]] === ';';
+                  const replacement = hasSemicolon
+                    ? 'await waitFor(() => {\n  // TODO: Add assertion or condition\n  expect(true).toBe(true);\n})'
+                    : 'await waitFor(() => {\n  // TODO: Add assertion or condition\n  expect(true).toBe(true);\n});';
+
+                  return fixer.replaceText(targetNode, replacement);
+                }
+              });
+            }
+          } else if (body.type === 'BlockStatement') {
+            // Check for polling patterns - if it has a check function, it's valid
+            const sourceCode = context.getSourceCode();
+            const bodyText = sourceCode.getText(body);
+            if (!/if\s*\(|check|poll|retry/.test(bodyText)) {
+              // Check if the body only contains setTimeout
+              const hasOnlySetTimeout = body.body.length === 1 &&
+                body.body[0].type === 'ExpressionStatement' &&
+                body.body[0].expression.type === 'CallExpression' &&
+                body.body[0].expression.callee.name === 'setTimeout';
+
+              if (hasOnlySetTimeout) {
+                // Skip the regular error if in setup hook and allowed
+                if (isInSetupHook(node)) return;
+
+                context.report({
+                  node,
+                  messageId: 'useWaitFor'
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    function checkWaitForWithoutAssertion(node) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for waitFor with empty or no-op callback
+      if (node.callee.name === 'waitFor' ||
+          (node.callee.type === 'MemberExpression' &&
+           node.callee.property.name === 'waitFor')) {
+
+        const callback = node.arguments[0];
+        if (callback && callback.type === 'ArrowFunctionExpression') {
+          const body = callback.body;
+
+          // Check for empty body
+          if (body.type === 'BlockStatement') {
+            if (body.body.length === 0) {
+              // Skip the regular error if in setup hook and allowed
+              if (isInSetupHook(node)) return;
+
+              context.report({
+                node,
+                messageId: 'useWaitFor'
+              });
+            } else {
+              // Check if body only contains console.log or similar non-assertions
+              const hasAssertion = body.body.some(stmt => {
+                // Allow return statements (they return elements to wait for)
+                if (stmt.type === 'ReturnStatement') {
+                  return true;
+                }
+                const stmtText = context.getSourceCode().getText(stmt);
+                return /expect|assert|should|getBy|findBy|queryBy/.test(stmtText);
+              });
+
+              if (!hasAssertion) {
+                // Skip the regular error if in setup hook and allowed
+                if (isInSetupHook(node)) return;
+
+                context.report({
+                  node,
+                  messageId: 'useWaitFor'
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    function checkPlaywrightWaitForTimeout(node) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for page.waitForTimeout() in Playwright
+      if (node.callee.type === 'MemberExpression') {
+        const method = node.callee.property.name;
+        const obj = context.getSourceCode().getText(node.callee.object);
+
+        if (method === 'waitForTimeout' && /page|frame|context/.test(obj)) {
+          // Check timeout value if it's a literal
+          const timeoutArg = node.arguments[0];
+          if (timeoutArg && timeoutArg.type === 'Literal' && typeof timeoutArg.value === 'number') {
+            if (checkTimeoutValue(node, timeoutArg.value)) return;
+          }
+
+          // Skip the regular error if in setup hook and allowed
+          if (isInSetupHook(node)) return;
+
+          context.report({
+            node,
+            messageId: 'avoidUnconditionalWait',
+            fix(fixer) {
+              const sourceCode = context.getSourceCode();
+              const hasSemicolon = sourceCode.text[node.range[1]] === ';';
+
+              if (hasSemicolon) {
+                // Replace both the node and the semicolon
+                return fixer.replaceTextRange(
+                  [node.range[0], node.range[1] + 1],
+                  `${obj}.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector`
+                );
+              } else {
+                // Just replace the node
+                return fixer.replaceText(
+                  node,
+                  `${obj}.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector`
+                );
+              }
+            }
+          });
+        }
+      }
+    }
+
+    function checkBrowserPause(node) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for browser.pause() in WebdriverIO
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.object.name === 'browser' &&
+          node.callee.property.name === 'pause') {
+
+        // Check timeout value if it's a literal
+        const timeoutArg = node.arguments[0];
+        if (timeoutArg && timeoutArg.type === 'Literal' && typeof timeoutArg.value === 'number') {
+          if (checkTimeoutValue(node, timeoutArg.value)) return;
+        }
+
+        // Skip the regular error if in setup hook and allowed
+        if (isInSetupHook(node)) return;
+
+        context.report({
+          node,
+          messageId: 'avoidUnconditionalWait',
+          fix(fixer) {
+            const sourceCode = context.getSourceCode();
+            const hasSemicolon = sourceCode.text[node.range[1]] === ';';
+
+            if (hasSemicolon) {
+              return fixer.replaceTextRange(
+                [node.range[0], node.range[1] + 1],
+                'browser.waitUntil(() => element.isDisplayed()); // TODO: Add condition'
+              );
+            } else {
+              return fixer.replaceText(
+                node,
+                'browser.waitUntil(() => element.isDisplayed()); // TODO: Add condition'
+              );
+            }
+          }
+        });
+      }
+    }
+
+    function checkDriverSleep(node) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for driver.sleep() in Selenium
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.object.name === 'driver' &&
+          node.callee.property.name === 'sleep') {
+
+        // Check timeout value if it's a literal
+        const timeoutArg = node.arguments[0];
+        if (timeoutArg && timeoutArg.type === 'Literal' && typeof timeoutArg.value === 'number') {
+          if (checkTimeoutValue(node, timeoutArg.value)) return;
+        }
+
+        // Skip the regular error if in setup hook and allowed
+        if (isInSetupHook(node)) return;
+
+        context.report({
+          node,
+          messageId: 'avoidUnconditionalWait',
+          fix(fixer) {
+            const sourceCode = context.getSourceCode();
+            const hasSemicolon = sourceCode.text[node.range[1]] === ';';
+
+            if (hasSemicolon) {
+              return fixer.replaceTextRange(
+                [node.range[0], node.range[1] + 1],
+                'driver.wait(until.elementLocated(By.id(\'element\'))); // TODO: Add condition'
+              );
+            } else {
+              return fixer.replaceText(
+                node,
+                'driver.wait(until.elementLocated(By.id(\'element\'))); // TODO: Add condition'
+              );
+            }
+          }
+        });
+      }
+    }
+
+    function checkSleepPatterns(node) {
+      // Skip if it's an allowed method
+      if (isAllowedMethod(node)) return;
+
+      // Check for various sleep/delay/wait patterns
+      if (node.callee.type === 'Identifier') {
+        const name = node.callee.name;
+        if (/^(sleep|delay|wait|pause)$/i.test(name)) {
+          // Check if first argument is a number
+          const arg = node.arguments[0];
+          if (arg && (arg.type === 'Literal' && typeof arg.value === 'number')) {
+            // Check timeout value
+            if (checkTimeoutValue(node, arg.value)) return;
+
+            // Skip the regular error if in setup hook and allowed
+            if (isInSetupHook(node)) return;
+
+            context.report({
+              node,
+              messageId: 'useWaitFor'
+            });
+          }
+        }
+      }
+
+      // Check for Thread.sleep
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.object.name === 'Thread' &&
+          node.callee.property.name === 'sleep') {
+        // Check timeout value if it's a literal
+        const timeoutArg = node.arguments[0];
+        if (timeoutArg && timeoutArg.type === 'Literal' && typeof timeoutArg.value === 'number') {
+          if (checkTimeoutValue(node, timeoutArg.value)) return;
+        }
+
+        // Skip the regular error if in setup hook and allowed
+        if (isInSetupHook(node)) return;
+
+        context.report({
+          node,
+          messageId: 'avoidUnconditionalWait'
+        });
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        checkWaitWithoutCondition(node);
+        checkSetTimeout(node);
+        checkSetInterval(node);
+        checkWaitForWithoutAssertion(node);
+        checkPlaywrightWaitForTimeout(node);
+        checkBrowserPause(node);
+        checkDriverSleep(node);
+        checkSleepPatterns(node);
+      },
+
+      AwaitExpression(node) {
+        if (node.argument) {
+          // Pass the entire await expression for proper fix context
+          checkPromiseWithTimeout(node.argument, node);
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/no-unconditional-wait.test.js
+++ b/tests/lib/rules/no-unconditional-wait.test.js
@@ -1,0 +1,720 @@
+/**
+ * @fileoverview Tests for no-unconditional-wait rule
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/no-unconditional-wait');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
+
+const ruleTester = getRuleTester();
+
+ruleTester.run('no-unconditional-wait', rule, {
+  valid: [
+    // Test configuration options - maxTimeout allows timeouts within limit
+    {
+      code: 'setTimeout(() => {}, 500);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000, allowedMethods: ['setTimeout'] }]  // Allow setTimeout within limit
+    },
+    {
+      code: 'setTimeout(() => {}, 1500);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 2000, allowedMethods: ['setTimeout'] }]  // Allow setTimeout within limit
+    },
+
+    // Test configuration options - allowInSetup (with high maxTimeout to allow the timeouts)
+    {
+      code: `
+        beforeEach(async () => {
+          await new Promise(resolve => setTimeout(resolve, 2000));
+        });
+      `,
+      filename: 'Component.test.js',
+      options: [{ allowInSetup: true, maxTimeout: 10000 }]
+    },
+    {
+      code: `
+        beforeAll(() => {
+          setTimeout(() => {}, 3000);
+        });
+      `,
+      filename: 'Component.test.js',
+      options: [{ allowInSetup: true, maxTimeout: 10000 }]
+    },
+    {
+      code: `
+        afterEach(() => {
+          cy.wait(5000);
+        });
+      `,
+      filename: 'cypress/e2e/test.cy.js',
+      options: [{ allowInSetup: true, maxTimeout: 10000 }]
+    },
+    {
+      code: `
+        afterAll(async () => {
+          await browser.pause(2000);
+        });
+      `,
+      filename: 'wdio/test.spec.js',
+      options: [{ allowInSetup: true, maxTimeout: 10000 }]
+    },
+
+    // Test configuration options - allowedMethods
+    {
+      code: 'await debounceWait(500);',
+      filename: 'Component.test.js',
+      options: [{ allowedMethods: ['debounceWait'] }]
+    },
+    {
+      code: 'await customTimeout(2000);',
+      filename: 'Component.test.js',
+      options: [{ allowedMethods: ['customTimeout'] }]
+    },
+    {
+      code: 'page.waitForTimeout(3000);',
+      filename: 'playwright/test.spec.js',
+      options: [{ allowedMethods: ['waitForTimeout'] }]
+    },
+    {
+      code: 'cy.wait(2000);',
+      filename: 'cypress/e2e/test.cy.js',
+      options: [{ allowedMethods: ['wait'] }]
+    },
+
+    // Combined options
+    {
+      code: `
+        beforeEach(() => {
+          setTimeout(() => {}, 900);
+        });
+      `,
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000, allowInSetup: true }]
+    },
+    {
+      code: 'await sleep(800);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000, allowedMethods: ['sleep'] }]
+    },
+
+    // Edge cases - timeout at exactly maxTimeout
+    {
+      code: 'setTimeout(() => {}, 1000);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000, allowedMethods: ['setTimeout'] }]  // Allow setTimeout within limit
+    },
+
+    // Original valid tests
+    // Non-test files should pass
+    {
+      code: `
+        cy.wait(5000);
+        setTimeout(() => {}, 1000);
+      `,
+      filename: 'src/utils.js'
+    },
+
+    // Cypress wait with alias
+    {
+      code: 'cy.wait(\'@apiCall\');',
+      filename: 'cypress/e2e/test.cy.js'
+    },
+
+    // Cypress wait with array of aliases
+    {
+      code: 'cy.wait([\'@api1\', \'@api2\']);',
+      filename: 'cypress/e2e/test.cy.js'
+    },
+
+    // waitFor with proper assertion
+    {
+      code: `
+        await waitFor(() => {
+          expect(screen.getByText('Loaded')).toBeInTheDocument();
+        });
+      `,
+      filename: 'Component.test.js'
+    },
+
+    // waitFor with return statement
+    {
+      code: `
+        await waitFor(() => {
+          return screen.getByText('Loaded');
+        });
+      `,
+      filename: 'Component.test.js'
+    },
+
+    // page.waitForSelector in Playwright
+    {
+      code: 'await page.waitForSelector(\'.loaded\');',
+      filename: 'playwright/test.spec.js'
+    },
+
+    // page.waitForLoadState in Playwright
+    {
+      code: 'await page.waitForLoadState(\'networkidle\');',
+      filename: 'playwright/test.spec.js'
+    },
+
+    // setTimeout in mock context
+    {
+      code: `
+        jest.fn(() => {
+          setTimeout(() => {}, 1000);
+        });
+      `,
+      filename: 'Component.test.js'
+    },
+
+    // setInterval with condition check
+    {
+      code: `
+        const interval = setInterval(() => {
+          if (condition) {
+            clearInterval(interval);
+          }
+        }, 100);
+      `,
+      filename: 'utils.test.js'
+    },
+
+    // Promise with resolve condition
+    {
+      code: `
+        await new Promise(resolve => {
+          const check = () => {
+            if (element.value) resolve();
+            else setTimeout(check, 100);
+          };
+          check();
+        });
+      `,
+      filename: 'Component.test.js'
+    },
+
+    // Cypress wait with string (not a number)
+    {
+      code: 'cy.wait(\'@route\');',
+      filename: 'cypress/e2e/test.cy.js'
+    },
+
+    // Not a wait function
+    {
+      code: 'wait.for.something();',
+      filename: 'Component.test.js'
+    },
+
+    // setTimeout within Promise constructor with parent checks - removed as it's already covered above
+
+    // Arrow function within Promise constructor - checks parent traversal
+    {
+      code: `
+        const delay = () => new Promise(resolve => {
+          setTimeout(resolve, 100);
+        });
+      `,
+      filename: 'ArrowPromise.test.js'
+    },
+
+    // page.waitForTimeout within setup hook with allowInSetup and higher maxTimeout
+    {
+      code: `
+        beforeEach(async () => {
+          await page.waitForTimeout(2000);
+        });
+      `,
+      filename: 'playwright.test.js',
+      options: [{ allowInSetup: true, maxTimeout: 5000 }]
+    },
+
+    // browser.pause within setup hook with allowInSetup
+    {
+      code: `
+        beforeAll(async () => {
+          await browser.pause(1000);
+        });
+      `,
+      filename: 'webdriver.test.js',
+      options: [{ allowInSetup: true }]
+    },
+
+    // driver.sleep within setup hook with allowInSetup
+    {
+      code: `
+        afterEach(async () => {
+          await driver.sleep(500);
+        });
+      `,
+      filename: 'selenium.test.js',
+      options: [{ allowInSetup: true }]
+    }
+  ],
+
+  invalid: [
+    // Test configuration options - maxTimeout violations
+    {
+      code: 'setTimeout(() => {}, 1001);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000 }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 1001, maxTimeout: 1000 }
+      }]
+    },
+    {
+      code: 'cy.wait(2000);',
+      filename: 'cypress/e2e/test.cy.js',
+      options: [{ maxTimeout: 1500 }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 2000, maxTimeout: 1500 }
+      }]
+    },
+    {
+      code: 'await new Promise(resolve => setTimeout(resolve, 3000));',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 2000 }],
+      errors: [
+        {
+          messageId: 'exceedsMaxTimeout',
+          data: { timeout: 3000, maxTimeout: 2000 }
+        },
+        {
+          messageId: 'exceedsMaxTimeout',
+          data: { timeout: 3000, maxTimeout: 2000 }
+        }
+      ]
+    },
+    {
+      code: 'await page.waitForTimeout(5000);',
+      filename: 'playwright/test.spec.js',
+      options: [{ maxTimeout: 3000 }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 5000, maxTimeout: 3000 }
+      }]
+    },
+    {
+      code: 'await browser.pause(2500);',
+      filename: 'wdio/test.spec.js',
+      options: [{ maxTimeout: 2000 }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 2500, maxTimeout: 2000 }
+      }]
+    },
+    {
+      code: 'await driver.sleep(1500);',
+      filename: 'selenium/test.spec.js',
+      options: [{ maxTimeout: 1000 }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 1500, maxTimeout: 1000 }
+      }]
+    },
+    {
+      code: 'await sleep(2000);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1500 }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 2000, maxTimeout: 1500 }
+      }]
+    },
+    {
+      code: 'Thread.sleep(1200);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000 }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 1200, maxTimeout: 1000 }
+      }]
+    },
+    {
+      code: 'setInterval(() => {}, 1100);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000 }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 1100, maxTimeout: 1000 }
+      }]
+    },
+
+    // Test configuration options - allowInSetup: false
+    {
+      code: `
+        beforeEach(() => {
+          setTimeout(() => {}, 500);
+        });
+      `,
+      filename: 'Component.test.js',
+      options: [{ allowInSetup: false }],
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+    {
+      code: `
+        beforeAll(async () => {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        });
+      `,
+      filename: 'Component.test.js',
+      options: [{ allowInSetup: false }],
+      errors: [{
+        messageId: 'useWaitFor'
+      }],
+      output: `
+        beforeAll(async () => {
+          await waitFor(() => {
+  // TODO: Add assertion or condition
+  expect(true).toBe(true);
+});
+        });
+      `
+    },
+    {
+      code: `
+        afterEach(() => {
+          cy.wait(2000);
+        });
+      `,
+      filename: 'cypress/e2e/test.cy.js',
+      options: [{ allowInSetup: false, maxTimeout: 1500 }],  // Add maxTimeout to make it explicit
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 2000, maxTimeout: 1500 }
+      }]
+    },
+    {
+      code: `
+        afterAll(async () => {
+          await page.waitForTimeout(1000);
+        });
+      `,
+      filename: 'playwright/test.spec.js',
+      options: [{ allowInSetup: false }],
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: `
+        afterAll(async () => {
+          await page.waitForSelector('[data-testid="element"]'); // TODO: Replace with actual selector
+        });
+      `
+    },
+
+    // Test configuration options - methods not in allowedMethods
+    {
+      code: 'await sleep(500);',
+      filename: 'Component.test.js',
+      options: [{ allowedMethods: ['delay'] }],  // sleep not allowed
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+    {
+      code: 'cy.wait(1000);',
+      filename: 'cypress/e2e/test.cy.js',
+      options: [{ allowedMethods: ['pause'] }],  // wait not allowed
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'cy.wait(\'@apiCall\') // TODO: Replace with actual alias or remove wait;'
+    },
+
+    // Test combined options
+    {
+      code: `
+        beforeEach(() => {
+          setTimeout(() => {}, 2000);
+        });
+      `,
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000, allowInSetup: true }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 2000, maxTimeout: 1000 }
+      }]
+    },
+    {
+      code: `
+        beforeEach(() => {
+          setTimeout(() => {}, 500);
+        });
+      `,
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000, allowInSetup: false }],
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+    {
+      code: 'await sleep(1500);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000, allowedMethods: ['delay'] }],
+      errors: [{
+        messageId: 'exceedsMaxTimeout',
+        data: { timeout: 1500, maxTimeout: 1000 }
+      }]
+    },
+
+    // Test that below maxTimeout still triggers regular errors
+    {
+      code: 'setTimeout(() => {}, 500);',
+      filename: 'Component.test.js',
+      options: [{ maxTimeout: 1000 }],
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // Test Promise with only setTimeout in body - special case
+    {
+      code: `
+        await new Promise(resolve => {
+          setTimeout(() => doSomething(), 1000);
+        });
+      `,
+      filename: 'OnlySetTimeout.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // Test fix for page.waitForTimeout with semicolon
+    {
+      code: 'await page.waitForTimeout(1000);',
+      filename: 'playwright.test.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'await page.waitForSelector(\'[data-testid="element"]\'); // TODO: Replace with actual selector'
+    },
+
+    // Test fix for browser.pause with semicolon
+    {
+      code: 'await browser.pause(2000);',
+      filename: 'webdriver.test.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'await browser.waitUntil(() => element.isDisplayed()); // TODO: Add condition'
+    },
+
+    // Test fix for driver.sleep with semicolon
+    {
+      code: 'await driver.sleep(1500);',
+      filename: 'selenium.test.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'await driver.wait(until.elementLocated(By.id(\'element\'))); // TODO: Add condition'
+    },
+
+    // Original invalid tests
+    // Cypress wait with numeric delay
+    {
+      code: 'cy.wait(5000);',
+      filename: 'cypress/e2e/test.cy.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'cy.wait(\'@apiCall\') // TODO: Replace with actual alias or remove wait;'
+    },
+
+    // Cypress wait with small delay
+    {
+      code: 'cy.wait(100);',
+      filename: 'cypress/e2e/test.cy.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'cy.wait(\'@apiCall\') // TODO: Replace with actual alias or remove wait;'
+    },
+
+    // setTimeout with fixed delay
+    {
+      code: 'setTimeout(() => {}, 1000);',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // setTimeout with callback
+    {
+      code: 'setTimeout(callback, 2000);',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // setInterval without clear condition
+    {
+      code: 'setInterval(() => { console.log(\'checking\'); }, 500);',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useDataTestId'
+      }]
+    },
+
+    // Promise with only setTimeout
+    {
+      code: 'await new Promise(resolve => setTimeout(resolve, 1000));',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }],
+      output: `await waitFor(() => {
+  // TODO: Add assertion or condition
+  expect(true).toBe(true);
+});`
+    },
+
+    // Promise with inline setTimeout
+    {
+      code: 'await new Promise(r => setTimeout(r, 500));',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }],
+      output: `await waitFor(() => {
+  // TODO: Add assertion or condition
+  expect(true).toBe(true);
+});`
+    },
+
+    // waitFor with empty callback
+    {
+      code: 'await waitFor(() => {});',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // waitFor with only console.log
+    {
+      code: `
+        await waitFor(() => {
+          console.log('waiting');
+        });
+      `,
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // page.waitForTimeout in Playwright
+    {
+      code: 'await page.waitForTimeout(3000);',
+      filename: 'playwright/test.spec.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'await page.waitForSelector(\'[data-testid="element"]\'); // TODO: Replace with actual selector'
+    },
+
+    // browser.pause in WebdriverIO
+    {
+      code: 'await browser.pause(2000);',
+      filename: 'wdio/test.spec.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'await browser.waitUntil(() => element.isDisplayed()); // TODO: Add condition'
+    },
+
+    // driver.sleep in Selenium
+    {
+      code: 'await driver.sleep(1000);',
+      filename: 'selenium/test.spec.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }],
+      output: 'await driver.wait(until.elementLocated(By.id(\'element\'))); // TODO: Add condition'
+    },
+
+    // Thread.sleep in various forms
+    {
+      code: 'Thread.sleep(500);',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'avoidUnconditionalWait'
+      }]
+    },
+
+    // delay function call
+    {
+      code: 'await delay(1000);',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // sleep function call
+    {
+      code: 'await sleep(2000);',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // wait function with numeric argument
+    {
+      code: 'await wait(500);',
+      filename: 'Component.test.js',
+      errors: [{
+        messageId: 'useWaitFor'
+      }]
+    },
+
+    // Multiple violations in same test
+    {
+      code: `
+        cy.wait(1000);
+        setTimeout(() => {}, 2000);
+        await new Promise(r => setTimeout(r, 500));
+      `,
+      filename: 'cypress/e2e/test.cy.js',
+      errors: [
+        { messageId: 'avoidUnconditionalWait' },
+        { messageId: 'useWaitFor' },
+        { messageId: 'useWaitFor' }
+      ],
+      output: `
+        cy.wait('@apiCall') // TODO: Replace with actual alias or remove wait;
+        setTimeout(() => {}, 2000);
+        await waitFor(() => {
+  // TODO: Add assertion or condition
+  expect(true).toBe(true);
+});
+      `
+    },
+
+    // Nested setTimeout
+    {
+      code: `
+        setTimeout(() => {
+          setTimeout(() => {
+            done();
+          }, 100);
+        }, 200);
+      `,
+      filename: 'Component.test.js',
+      errors: [
+        { messageId: 'useWaitFor' },
+        { messageId: 'useWaitFor' }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
## Existing Behavior
Tests can use unconditional waits like `cy.wait(2000)`, `setTimeout()`, `page.waitForTimeout()`, and `new Promise(resolve => setTimeout(resolve, 1000))` without restrictions. These fixed timeouts make tests slow and unreliable across different environments. No automated detection exists for unconditional wait patterns that don't wait for specific conditions.

## Intended New Behavior
The new `no-unconditional-wait` rule detects and prevents unconditional waits in test files. It identifies problematic patterns like Cypress numeric waits, Playwright timeout waits, generic sleep functions, Promise-based delays, and polling without conditions. The rule provides auto-fixes for common patterns and supports configuration options for maximum timeout limits, setup hook exceptions, and method allowlists.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo
1. Install the plugin and configure the `no-unconditional-wait` rule in your ESLint config
2. Test the rule detection by running ESLint on the example file: `npx eslint examples/no-unconditional-wait-violations.test.js`
3. Verify it flags violations like:
   - `cy.wait(2000)` → suggests using `cy.wait('@alias')`
   - `page.waitForTimeout(3000)` → suggests using `page.waitForSelector()`
   - `await sleep(1000)` → suggests using `waitFor()` with conditions
   - `new Promise(resolve => setTimeout(resolve, 2000))` → suggests conditional waiting
4. Test configuration options:
   - Set `maxTimeout: 500` and verify it flags timeouts > 500ms
   - Set `allowInSetup: false` and verify it flags waits in `beforeEach` hooks  
   - Set `allowedMethods: ["customDelay"]` and verify `customDelay()` calls are allowed
5. Test auto-fixes by running `npx eslint --fix` and verify suggested replacements are applied
6. Verify the rule only applies to test files (files with `.test.`, `.spec.` patterns)