### PR TITLE
feat: no-viewport-dependent

### DIFF
--- a/docs/rules/no-viewport-dependent.md
+++ b/docs/rules/no-viewport-dependent.md
@@ -471,9 +471,8 @@ expect(window.matchMedia('(max-width: 768px)').matches).toBe(true);
 
 ## Related Rules
 
-- [no-index-queries](./no-index-queries.md) - Prevents position-dependent queries
 - [no-animation-wait](./no-animation-wait.md) - Prevents animation timing dependencies
-- [no-immediate-assertions](./no-immediate-assertions.md) - Requires proper waiting
+- [no-hard-coded-timeout](./no-hard-coded-timeout.md) - Prevents hard-coded timeout values
 
 ## Further Reading
 

--- a/docs/rules/no-viewport-dependent.md
+++ b/docs/rules/no-viewport-dependent.md
@@ -1,0 +1,484 @@
+# no-viewport-dependent
+
+Prevent tests that depend on specific viewport sizes or screen dimensions.
+
+## Rule Details
+
+Viewport-dependent tests are brittle and can fail across different environments:
+
+- Different screen resolutions and display densities
+- Varying browser window sizes in CI/CD environments
+- Mobile vs desktop viewport differences
+- Browser zoom levels affecting element positioning
+- CSS media queries changing layout based on viewport size
+- Element visibility depending on scroll position
+
+This rule helps prevent test flakiness by detecting tests that rely on specific viewport dimensions or screen properties.
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+```json
+{
+  "test-flakiness/no-viewport-dependent": [
+    "error",
+    {
+      "allowViewportSetup": true,
+      "allowResponsiveTests": false,
+      "ignoreMediaQueries": false
+    }
+  ]
+}
+```
+
+### `allowViewportSetup` (default: `true`)
+
+When set to `true`, allows viewport configuration in test setup hooks.
+
+```javascript
+// With allowViewportSetup: true (default)
+beforeEach(() => {
+  cy.viewport(1920, 1080); // ✅ Allowed in setup
+});
+
+// With allowViewportSetup: false
+beforeEach(() => {
+  cy.viewport(1920, 1080); // ❌ Not allowed
+});
+```
+
+### `allowResponsiveTests` (default: `false`)
+
+When set to `true`, allows tests specifically designed for responsive design testing.
+
+```javascript
+// With allowResponsiveTests: true
+describe("Responsive design", () => {
+  cy.viewport("macbook-15");
+  cy.get('[data-cy="mobile-menu"]').should("not.be.visible"); // ✅ Allowed
+});
+
+// With allowResponsiveTests: false (default)
+cy.get('[data-cy="mobile-menu"]').should("not.be.visible"); // ❌ Not allowed
+```
+
+### `ignoreMediaQueries` (default: `false`)
+
+When set to `true`, ignores tests that specifically test CSS media query behavior.
+
+```javascript
+// With ignoreMediaQueries: true
+expect(window.matchMedia("(max-width: 768px)").matches).toBe(true); // ✅ Ignored
+
+// With ignoreMediaQueries: false (default)
+expect(window.matchMedia("(max-width: 768px)").matches).toBe(true); // ❌ Not allowed
+```
+
+## Examples
+
+### ❌ Incorrect
+
+```javascript
+// Viewport size checks
+expect(window.innerWidth).toBe(1920);
+expect(window.innerHeight).toBeGreaterThan(1000);
+
+// Screen dimension checks
+expect(screen.width).toBe(1920);
+expect(screen.height).toBe(1080);
+
+// Media query matching
+expect(window.matchMedia("(max-width: 768px)").matches).toBe(false);
+expect(window.matchMedia("(min-width: 1200px)").matches).toBe(true);
+
+// Element position checks that depend on viewport
+expect(element.getBoundingClientRect().top).toBe(100);
+expect(element.offsetLeft).toBeLessThan(500);
+
+// Scroll position checks
+expect(window.scrollY).toBe(0);
+expect(document.documentElement.scrollTop).toBeGreaterThan(200);
+
+// CSS computed style checks that vary by viewport
+expect(getComputedStyle(element).display).toBe("none"); // Hidden on mobile
+expect(getComputedStyle(element).width).toBe("300px");
+
+// Viewport-dependent visibility checks
+expect(element).toBeVisible(); // May fail on different screen sizes
+cy.get(".mobile-menu").should("be.visible"); // Depends on viewport
+
+// Playwright viewport-dependent tests
+await expect(page.locator(".desktop-only")).toBeVisible();
+await page.setViewportSize({ width: 375, height: 667 });
+await expect(page.locator(".mobile-only")).toBeVisible();
+
+// Element positioning assertions
+const rect = await element.boundingBox();
+expect(rect.x).toBe(100); // Position depends on viewport
+expect(rect.y).toBeLessThan(300);
+
+// Responsive grid/layout checks
+const columns = await page.locator(".grid-column").count();
+expect(columns).toBe(3); // May be different on smaller screens
+
+// Touch/hover behavior based on device type
+if ("ontouchstart" in window) {
+  expect(touchEnabled).toBe(true);
+}
+
+// Orientation-dependent tests
+expect(window.orientation).toBe(0); // Portrait
+expect(screen.orientation.angle).toBe(90); // Landscape
+
+// CSS breakpoint testing
+cy.viewport("iphone-6");
+cy.get(".hamburger-menu").should("be.visible");
+```
+
+### ✅ Correct
+
+```javascript
+// Test functionality regardless of viewport
+expect(getUserData()).toEqual(expectedData);
+expect(calculateTotal(items)).toBe(150);
+
+// Use semantic queries instead of position-based
+expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+expect(screen.getByText("Welcome")).toBeVisible();
+
+// Test responsive behavior with explicit viewport setup
+describe("Navigation", () => {
+  beforeEach(() => {
+    // Set consistent viewport for all tests in this suite
+    cy.viewport(1920, 1080);
+  });
+
+  it("shows desktop navigation", () => {
+    cy.get('[data-cy="desktop-nav"]').should("be.visible");
+    cy.get('[data-cy="mobile-nav"]').should("not.exist");
+  });
+});
+
+// Test both responsive states explicitly
+describe("Responsive menu", () => {
+  it("shows desktop menu on large screens", () => {
+    cy.viewport(1200, 800);
+    cy.get('[data-cy="desktop-menu"]').should("be.visible");
+  });
+
+  it("shows mobile menu on small screens", () => {
+    cy.viewport(375, 667);
+    cy.get('[data-cy="mobile-menu"]').should("be.visible");
+  });
+});
+
+// Use data attributes for responsive elements
+<nav data-testid={isMobile ? "mobile-nav" : "desktop-nav"}>
+  {/* Navigation content */}
+</nav>;
+
+// Test with CSS classes instead of viewport dimensions
+expect(element).toHaveClass("mobile-layout");
+expect(element).not.toHaveClass("desktop-layout");
+
+// Mock viewport-related APIs in tests
+beforeEach(() => {
+  Object.defineProperty(window, "innerWidth", {
+    writable: true,
+    configurable: true,
+    value: 1024,
+  });
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: query === "(min-width: 768px)",
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    })),
+  });
+});
+
+// Test behavior instead of layout
+test("toggles menu visibility", async () => {
+  const user = userEvent.setup();
+  render(<Navigation />);
+
+  const menuToggle = screen.getByRole("button", { name: /menu/i });
+  await user.click(menuToggle);
+
+  expect(screen.getByRole("navigation")).toBeInTheDocument();
+});
+
+// Use Playwright with consistent viewport setup
+test.beforeEach(async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+});
+
+// Test content accessibility regardless of layout
+test("all content is accessible", async ({ page }) => {
+  await page.goto("/");
+
+  // Test that all interactive elements are reachable
+  const buttons = await page.locator("button").all();
+  for (const button of buttons) {
+    await expect(button).toBeEnabled();
+  }
+});
+
+// Mock CSS media queries for consistent testing
+const createMatchMedia = (width) => {
+  return (query) => ({
+    matches: evaluateMediaQuery(query, width),
+    media: query,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  });
+};
+
+window.matchMedia = createMatchMedia(1024);
+```
+
+## Best Practices
+
+### 1. Set Consistent Viewport in Test Setup
+
+Establish a standard viewport for all tests:
+
+```javascript
+// Cypress
+beforeEach(() => {
+  cy.viewport(1280, 720); // Standard viewport for all tests
+});
+
+// Playwright
+test.beforeEach(async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+});
+
+// Puppeteer
+beforeEach(async () => {
+  await page.setViewport({ width: 1280, height: 720 });
+});
+```
+
+### 2. Test Responsive Behavior Explicitly
+
+When testing responsive design, be explicit about viewport changes:
+
+```javascript
+describe("Responsive design", () => {
+  const testViewports = [
+    { name: "mobile", width: 375, height: 667 },
+    { name: "tablet", width: 768, height: 1024 },
+    { name: "desktop", width: 1920, height: 1080 },
+  ];
+
+  testViewports.forEach(({ name, width, height }) => {
+    describe(`${name} viewport`, () => {
+      beforeEach(() => {
+        cy.viewport(width, height);
+      });
+
+      it("displays appropriate navigation", () => {
+        if (name === "mobile") {
+          cy.get('[data-cy="mobile-nav"]').should("be.visible");
+        } else {
+          cy.get('[data-cy="desktop-nav"]').should("be.visible");
+        }
+      });
+    });
+  });
+});
+```
+
+### 3. Use Semantic Queries Instead of Position-Based
+
+Focus on what users see and do rather than layout details:
+
+```javascript
+// Instead of position-based checks
+expect(element.getBoundingClientRect().top).toBe(100);
+
+// Use semantic meaning
+expect(screen.getByRole("banner")).toBeInTheDocument();
+expect(screen.getByRole("navigation")).toBeVisible();
+```
+
+### 4. Mock Viewport-Related APIs
+
+Mock browser APIs that depend on viewport:
+
+```javascript
+const mockMatchMedia = (query) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+});
+
+beforeEach(() => {
+  window.matchMedia = jest.fn().mockImplementation(mockMatchMedia);
+
+  // Mock specific breakpoints
+  window.matchMedia.mockImplementation((query) => {
+    if (query === "(max-width: 768px)") {
+      return { ...mockMatchMedia(query), matches: false };
+    }
+    return mockMatchMedia(query);
+  });
+});
+```
+
+### 5. Test Behavior, Not Layout
+
+Focus on functional testing rather than visual layout:
+
+```javascript
+// Instead of testing specific layout
+expect(getComputedStyle(element).display).toBe("grid");
+
+// Test the behavior
+test("displays all navigation items", () => {
+  const navItems = ["Home", "About", "Contact"];
+  navItems.forEach((item) => {
+    expect(screen.getByRole("link", { name: item })).toBeInTheDocument();
+  });
+});
+```
+
+### 6. Use CSS Classes for State Detection
+
+Use CSS classes to indicate responsive states:
+
+```javascript
+// Component with responsive logic
+function Navigation() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 768px)");
+    setIsMobile(mediaQuery.matches);
+  }, []);
+
+  return (
+    <nav className={isMobile ? "mobile-nav" : "desktop-nav"}>
+      {/* Navigation content */}
+    </nav>
+  );
+}
+
+// Test with class-based assertions
+expect(screen.getByRole("navigation")).toHaveClass("desktop-nav");
+```
+
+## Framework-Specific Examples
+
+### React Testing Library
+
+```javascript
+// Mock window properties
+beforeEach(() => {
+  // Mock window.innerWidth
+  Object.defineProperty(window, "innerWidth", {
+    writable: true,
+    configurable: true,
+    value: 1024,
+  });
+
+  // Mock matchMedia
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: query.includes("1024"),
+      media: query,
+    })),
+  });
+});
+```
+
+### Cypress
+
+```javascript
+// Viewport testing with explicit setup
+describe("Responsive Components", () => {
+  const viewports = [
+    { device: "mobile", width: 375, height: 667 },
+    { device: "desktop", width: 1920, height: 1080 },
+  ];
+
+  viewports.forEach(({ device, width, height }) => {
+    context(`${device} view`, () => {
+      beforeEach(() => {
+        cy.viewport(width, height);
+      });
+
+      it("renders correctly", () => {
+        cy.visit("/");
+        cy.get('[data-cy="content"]').should("be.visible");
+      });
+    });
+  });
+});
+```
+
+### Playwright
+
+```javascript
+// Test multiple viewports
+const devices = ["Desktop Chrome", "iPhone 12", "iPad Pro"];
+
+devices.forEach((deviceName) => {
+  test.describe(`${deviceName}`, () => {
+    test.use({ ...devices[deviceName] });
+
+    test("renders navigation", async ({ page }) => {
+      await page.goto("/");
+      await expect(page.locator("nav")).toBeVisible();
+    });
+  });
+});
+```
+
+## When Not To Use It
+
+This rule may not be suitable if:
+
+- You're specifically testing responsive design behavior
+- You're building viewport-aware components or libraries
+- You're testing CSS media query functionality
+- You're working with maps or visualization components that depend on dimensions
+
+In these cases:
+
+```javascript
+// Disable for responsive design tests
+// eslint-disable-next-line test-flakiness/no-viewport-dependent
+expect(window.matchMedia('(max-width: 768px)').matches).toBe(true);
+
+// Or configure for responsive testing
+{
+  "test-flakiness/no-viewport-dependent": ["error", {
+    "allowResponsiveTests": true,
+    "allowViewportSetup": true
+  }]
+}
+```
+
+## Related Rules
+
+- [no-index-queries](./no-index-queries.md) - Prevents position-dependent queries
+- [no-animation-wait](./no-animation-wait.md) - Prevents animation timing dependencies
+- [no-immediate-assertions](./no-immediate-assertions.md) - Requires proper waiting
+
+## Further Reading
+
+- [Responsive Design Testing Strategies](https://web.dev/responsive-web-design-basics/)
+- [Cypress - Viewport Testing](https://docs.cypress.io/api/commands/viewport)
+- [Playwright - Emulation](https://playwright.dev/docs/emulation)
+- [Testing Library - Responsive Tests](https://kentcdodds.com/blog/testing-implementation-details)
+- [CSS Media Queries in Tests](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries)

--- a/examples/no-viewport-dependent-violations.test.js
+++ b/examples/no-viewport-dependent-violations.test.js
@@ -34,7 +34,7 @@ describe('Viewport Dependent Violations', () => {
     expect(window.scrollY).toBe(0);
     expect(window.pageYOffset).toBe(0);
     expect(document.documentElement.scrollTop).toBe(0);
-    expect(element.scrollTop).toBeLessThan(100);
+    expect(someDiv.scrollTop).toBeLessThan(100); // Using non-mock element
   });
 
   // ❌ BAD: Media query based tests

--- a/examples/no-viewport-dependent-violations.test.js
+++ b/examples/no-viewport-dependent-violations.test.js
@@ -1,0 +1,136 @@
+/**
+ * Examples of no-viewport-dependent rule violations
+ * These patterns should be detected by the eslint-plugin-test-flakiness
+ */
+
+describe('Viewport Dependent Violations', () => {
+  // ❌ BAD: Checking window dimensions
+  it('should not check window dimensions', () => {
+    expect(window.innerWidth).toBeGreaterThan(768);
+    expect(window.innerHeight).toBeGreaterThan(600);
+    expect(window.outerWidth).toBe(1920);
+    expect(window.outerHeight).toBe(1080);
+  });
+
+  // ❌ BAD: Checking screen dimensions
+  it('should not check screen properties', () => {
+    expect(screen.width).toBe(1920);
+    expect(screen.height).toBe(1080);
+    expect(screen.availWidth).toBeGreaterThan(1000);
+    expect(screen.availHeight).toBeGreaterThan(700);
+  });
+
+  // ❌ BAD: Checking element positions
+  it('should not check absolute positions', () => {
+    const rect = element.getBoundingClientRect();
+    expect(rect.top).toBe(100);
+    expect(rect.left).toBe(50);
+    expect(rect.right).toBe(300);
+    expect(rect.bottom).toBe(200);
+  });
+
+  // ❌ BAD: Checking scroll positions
+  it('should not check scroll positions', () => {
+    expect(window.scrollY).toBe(0);
+    expect(window.pageYOffset).toBe(0);
+    expect(document.documentElement.scrollTop).toBe(0);
+    expect(element.scrollTop).toBeLessThan(100);
+  });
+
+  // ❌ BAD: Media query based tests
+  it('should not test media query states', () => {
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
+    expect(mediaQuery.matches).toBe(true);
+
+    const isMobile = window.matchMedia('(max-width: 767px)').matches;
+    expect(isMobile).toBe(false);
+  });
+
+  // ❌ BAD: Responsive visibility checks
+  it('should not check responsive visibility', () => {
+    // Checking if mobile menu is visible
+    if (window.innerWidth < 768) {
+      expect(mobileMenu).toBeVisible();
+      expect(desktopMenu).not.toBeVisible();
+    } else {
+      expect(desktopMenu).toBeVisible();
+      expect(mobileMenu).not.toBeVisible();
+    }
+  });
+
+  // ❌ BAD: CSS pixel-based assertions
+  it('should not assert exact pixel values', () => {
+    const styles = window.getComputedStyle(element);
+    expect(styles.width).toBe('250px');
+    expect(styles.height).toBe('100px');
+    expect(styles.marginTop).toBe('20px');
+    expect(styles.fontSize).toBe('16px');
+  });
+
+  // ❌ BAD: Viewport-relative units
+  it('should not test viewport units', () => {
+    const styles = window.getComputedStyle(element);
+    // These depend on viewport size
+    expect(styles.width).toBe('50vw');
+    expect(styles.height).toBe('100vh');
+    expect(styles.fontSize).toBe('5vmin');
+  });
+
+  // ❌ BAD: Element offset checks
+  it('should not check element offsets', () => {
+    expect(element.offsetTop).toBe(150);
+    expect(element.offsetLeft).toBe(200);
+    expect(element.offsetWidth).toBe(300);
+    expect(element.offsetHeight).toBe(400);
+  });
+
+  // ❌ BAD: Client dimensions
+  it('should not check client dimensions', () => {
+    expect(element.clientWidth).toBe(280);
+    expect(element.clientHeight).toBe(380);
+    expect(document.documentElement.clientWidth).toBe(1920);
+  });
+
+  // ❌ BAD: Intersection Observer based tests
+  it('should not test intersection directly', () => {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        expect(entry.intersectionRatio).toBeGreaterThan(0.5);
+        expect(entry.isIntersecting).toBe(true);
+      });
+    });
+
+    observer.observe(element);
+  });
+
+  // ❌ BAD: Resize Observer tests
+  it('should not test resize observations', () => {
+    const resizeObserver = new ResizeObserver(entries => {
+      for (let entry of entries) {
+        expect(entry.contentRect.width).toBe(500);
+        expect(entry.contentRect.height).toBe(300);
+      }
+    });
+
+    resizeObserver.observe(element);
+  });
+
+  // ❌ BAD: Touch/pointer position tests
+  it('should not test touch positions', () => {
+    const touch = {
+      clientX: 150,
+      clientY: 200,
+      screenX: 150,
+      screenY: 250
+    };
+
+    expect(touch.clientX).toBe(150);
+    expect(touch.screenY).toBe(250);
+  });
+
+  // ❌ BAD: Device pixel ratio checks
+  it('should not check device pixel ratio', () => {
+    expect(window.devicePixelRatio).toBe(2); // Retina display
+    expect(window.devicePixelRatio).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -63,9 +63,20 @@ module.exports = {
     const allowResponsiveTests = options.allowResponsiveTests || false;
     const ignoreMediaQueries = options.ignoreMediaQueries || false;
 
-    let hasSetViewport = false;
-    const reportedNodes = new Set(); // Track reported nodes to avoid duplicates
-    let isResponsiveTest = false; // Track if this is a responsive test
+    // State variables - initialized in Program handler to prevent leakage between files
+    let hasSetViewport;
+    let reportedNodes;
+    let isResponsiveTest;
+
+    // Helper function to consistently check for mock objects and DOM elements
+    function isMockOrElementObject(objectText) {
+      const allowedNames = ['mock', 'stub', 'spy', 'element', 'container', 'node', 'target', 'div'];
+      // Check for exact identifier matches or property access patterns
+      return allowedNames.some(name => {
+        // Check for exact identifier name or property access like "div." or "element."
+        return new RegExp(`^${name}(\\.|$)`, 'i').test(objectText) || objectText.toLowerCase() === name;
+      });
+    }
 
     function isViewportProperty(node) {
       if (node.type !== 'MemberExpression') return false;
@@ -122,7 +133,7 @@ module.exports = {
         const objectText = sourceCode.getText(node.object);
 
         // Don't flag clearly mock objects or element properties
-        if (/mock|stub|spy|div\.|element|container|node|target/.test(objectText)) {
+        if (isMockOrElementObject(objectText)) {
           return false;
         }
         return true;
@@ -144,8 +155,13 @@ module.exports = {
     }
 
     return {
-      // Check for responsive test context at the start
+      // Initialize state and check for responsive test context at the start
       Program(_node) {
+        // Initialize state variables for this file to prevent leakage between files
+        hasSetViewport = false;
+        reportedNodes = new Set();
+        isResponsiveTest = false;
+
         const sourceCode = context.getSourceCode();
         const text = sourceCode.getText();
         // Check if file has responsive test indicators
@@ -236,7 +252,7 @@ module.exports = {
 
           // Only flag if it doesn't look like a specific element property
           // Allow: div.scrollWidth, element.scrollTop, container.scrollLeft, etc.
-          if (!isResponsiveTest && !/^(div|element|container|node|target|mock|stub|spy)\b/i.test(objectText)) {
+          if (!isResponsiveTest && !isMockOrElementObject(objectText)) {
             reportOnce(node, 'avoidScrollCheck');
           }
         }
@@ -413,10 +429,8 @@ module.exports = {
       },
 
       'Program:exit'() {
-        // Reset for next file
-        hasSetViewport = false;
-        reportedNodes.clear();
-        isResponsiveTest = false;
+        // State variables are already initialized per file in Program handler
+        // No need to explicitly reset here
       }
     };
   }

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -466,7 +466,7 @@ module.exports = {
         if (!declarator || declarator.type !== 'VariableDeclarator') return;
         if (!declarator.init) return;
 
-        // Check AST structure directly instead of using getText()
+        // Check AST structure directly
         const init = declarator.init;
 
         // Only handle simple identifiers (window, screen)

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -172,10 +172,13 @@ module.exports = {
         return true;
       }
 
-      // Generic scroll properties
+      // Element scroll properties - filter out mock objects and known DOM elements
       if (ELEMENT_SCROLL_PROPERTIES.includes(node.property.name)) {
-        // Returns true for any scroll property on any object.
-        // Caller must handle context-specific filtering (mock objects, DOM elements, etc.)
+        // Skip if it's a mock object or known DOM element variable
+        if (isMockOrElementObject(node.object)) {
+          return false;
+        }
+        // Report scroll properties on non-mock objects
         return true;
       }
 
@@ -302,16 +305,9 @@ module.exports = {
           }
         }
 
-        // Handle scroll properties but avoid flagging element properties
-        if (isScrollProperty(node)) {
-          // Check if it's a mock object or DOM element
-          const isMockOrElement = isMockOrElementObject(node.object);
-
-          // Only flag if it doesn't look like a specific element property
-          // Allow: div.scrollWidth, element.scrollTop, container.scrollLeft, etc.
-          if (!isResponsiveTest && !isMockOrElement) {
-            reportOnce(node, 'avoidScrollCheck');
-          }
+        // Handle scroll properties (filtering is done inside isScrollProperty)
+        if (isScrollProperty(node) && !isResponsiveTest) {
+          reportOnce(node, 'avoidScrollCheck');
         }
       },
 

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -69,14 +69,26 @@ module.exports = {
     let isResponsiveTest;
 
     // Helper function to consistently check for mock objects and DOM elements
-    function isMockOrElementObject(objectText) {
+    function isMockOrElementObject(node) {
       const allowedNames = ['mock', 'stub', 'spy', 'element', 'container', 'node', 'target', 'div'];
-      // Check for names at start of identifier or property access patterns
-      return allowedNames.some(name => {
-        // Check for name at start of identifier (e.g., mockElement, stubObject)
-        // or exact match, or property access (e.g., div.something)
-        return new RegExp(`^${name}`, 'i').test(objectText) || objectText.toLowerCase() === name;
-      });
+
+      // For simple identifiers, check exact match or starts with allowed name
+      if (node.type === 'Identifier') {
+        const name = node.name.toLowerCase();
+        return allowedNames.some(allowed =>
+          name === allowed || name.startsWith(allowed)
+        );
+      }
+
+      // For member expressions, check the object name
+      if (node.type === 'MemberExpression' && node.object.type === 'Identifier') {
+        const objName = node.object.name.toLowerCase();
+        return allowedNames.some(allowed =>
+          objName === allowed || objName.startsWith(allowed)
+        );
+      }
+
+      return false;
     }
 
     function isViewportProperty(node) {
@@ -243,9 +255,8 @@ module.exports = {
 
         // Handle scroll properties but avoid flagging element properties
         if (isScrollProperty(node)) {
-          const sourceCode = context.getSourceCode();
-          const objectText = sourceCode.getText(node.object);
-          const isMockOrElement = isMockOrElementObject(objectText);
+          // Check if it's a mock object or DOM element
+          const isMockOrElement = isMockOrElementObject(node.object);
 
           // Only flag if it doesn't look like a specific element property
           // Allow: div.scrollWidth, element.scrollTop, container.scrollLeft, etc.

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -9,6 +9,19 @@ const { isTestFile, getFilename } = require('../utils/helpers');
 // Constants for allowed mock and DOM element names
 const ALLOWED_MOCK_ELEMENT_NAMES = ['mock', 'stub', 'spy', 'element', 'container', 'node', 'target', 'div'];
 
+// Constants for viewport properties
+const VIEWPORT_PROPERTIES = {
+  window: ['innerWidth', 'innerHeight', 'outerWidth', 'outerHeight'],
+  screen: ['width', 'height', 'availWidth', 'availHeight'],
+  visualViewport: ['width', 'height'],
+  documentElement: ['clientWidth', 'clientHeight'],
+  body: ['clientWidth', 'clientHeight', 'offsetWidth', 'offsetHeight']
+};
+
+// Constants for scroll properties
+const WINDOW_SCROLL_PROPERTIES = ['scrollY', 'scrollX', 'pageYOffset', 'pageXOffset'];
+const ELEMENT_SCROLL_PROPERTIES = ['scrollTop', 'scrollLeft', 'scrollHeight', 'scrollWidth'];
+
 // Pattern for detecting responsive test contexts
 const RESPONSIVE_TEST_PATTERN = /describe.*['"`](?:.*responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i;
 
@@ -51,9 +64,7 @@ module.exports = {
       avoidBoundingRect: 'getBoundingClientRect checks are viewport-dependent',
       useFixedViewport: 'Set a fixed viewport size before viewport-dependent assertions',
       avoidResizeListener: 'Resize event listeners are viewport-dependent',
-      setFixedViewport: 'Set a fixed viewport size before viewport-dependent assertions.',
       avoidMediaQuery: 'Media query checks can fail on different screen sizes.',
-      avoidPositionCheck: 'Position-based assertions are viewport-dependent.',
       avoidScrollCheck: 'Scroll-based checks depend on viewport size.'
     }
   },
@@ -83,20 +94,27 @@ module.exports = {
 
     // Helper function to consistently check for mock objects and DOM elements
     function isMockOrElementObject(node) {
-      // For simple identifiers, check exact match or starts with allowed name
+      // For simple identifiers, check exact match or common patterns
       if (node.type === 'Identifier') {
         const name = node.name.toLowerCase();
-        return ALLOWED_MOCK_ELEMENT_NAMES.some(allowed =>
-          name === allowed || name.startsWith(allowed)
-        );
+        return ALLOWED_MOCK_ELEMENT_NAMES.some(allowed => {
+          // Exact match
+          if (name === allowed) return true;
+          // Common patterns: mockElement, stubElement, etc.
+          if (name === `${allowed}element` || name === `${allowed}object`) return true;
+          // Check if it's a variable like mockDiv, stubContainer (limit suffix length to avoid false positives)
+          return name.startsWith(allowed) && name.length <= allowed.length + 10;
+        });
       }
 
       // For member expressions, check the object name
       if (node.type === 'MemberExpression' && node.object.type === 'Identifier') {
         const objName = node.object.name.toLowerCase();
-        return ALLOWED_MOCK_ELEMENT_NAMES.some(allowed =>
-          objName === allowed || objName.startsWith(allowed)
-        );
+        return ALLOWED_MOCK_ELEMENT_NAMES.some(allowed => {
+          if (objName === allowed) return true;
+          if (objName === `${allowed}element` || objName === `${allowed}object`) return true;
+          return objName.startsWith(allowed) && objName.length <= allowed.length + 10;
+        });
       }
 
       return false;
@@ -107,19 +125,19 @@ module.exports = {
 
       // window.innerWidth, window.innerHeight, etc.
       if (node.object.name === 'window' &&
-          ['innerWidth', 'innerHeight', 'outerWidth', 'outerHeight'].includes(node.property.name)) {
+          VIEWPORT_PROPERTIES.window.includes(node.property.name)) {
         return { type: 'viewport', property: `window.${node.property.name}` };
       }
 
       // screen.width, screen.height, etc.
       if (node.object.name === 'screen' &&
-          ['width', 'height', 'availWidth', 'availHeight'].includes(node.property.name)) {
+          VIEWPORT_PROPERTIES.screen.includes(node.property.name)) {
         return { type: 'screen', property: `screen.${node.property.name}` };
       }
 
       // visualViewport.width, visualViewport.height
       if (node.object.name === 'visualViewport' &&
-          ['width', 'height'].includes(node.property.name)) {
+          VIEWPORT_PROPERTIES.visualViewport.includes(node.property.name)) {
         return { type: 'viewport', property: `visualViewport.${node.property.name}` };
       }
 
@@ -127,7 +145,7 @@ module.exports = {
       if (node.object.type === 'MemberExpression' &&
           node.object.object.name === 'document' &&
           node.object.property.name === 'documentElement' &&
-          ['clientWidth', 'clientHeight'].includes(node.property.name)) {
+          VIEWPORT_PROPERTIES.documentElement.includes(node.property.name)) {
         return { type: 'viewport', property: `document.documentElement.${node.property.name}` };
       }
 
@@ -135,7 +153,7 @@ module.exports = {
       if (node.object.type === 'MemberExpression' &&
           node.object.object.name === 'document' &&
           node.object.property.name === 'body' &&
-          ['clientWidth', 'clientHeight', 'offsetWidth', 'offsetHeight'].includes(node.property.name)) {
+          VIEWPORT_PROPERTIES.body.includes(node.property.name)) {
         return { type: 'viewport', property: `document.body.${node.property.name}` };
       }
 
@@ -147,12 +165,12 @@ module.exports = {
 
       // window.scrollY, window.pageYOffset, etc.
       if (node.object.name === 'window' &&
-          ['scrollY', 'scrollX', 'pageYOffset', 'pageXOffset'].includes(node.property.name)) {
+          WINDOW_SCROLL_PROPERTIES.includes(node.property.name)) {
         return true;
       }
 
       // Generic scroll properties
-      if (['scrollTop', 'scrollLeft', 'scrollHeight', 'scrollWidth'].includes(node.property.name)) {
+      if (ELEMENT_SCROLL_PROPERTIES.includes(node.property.name)) {
         // Returns true for any element with scroll properties.
         // The caller is responsible for context-specific filtering (e.g., mock objects vs. real DOM elements).
         return true;
@@ -171,6 +189,78 @@ module.exports = {
           data
         });
       }
+    }
+
+    // Helper function to report viewport property issues
+    function reportViewportPropertyIssue(node, viewportInfo) {
+      if (!isResponsiveTest) {
+        if (viewportInfo.type === 'screen') {
+          reportOnce(node, 'avoidScreenCheck', { property: viewportInfo.property });
+        } else {
+          reportOnce(node, 'avoidViewportCheck', { property: viewportInfo.property });
+        }
+      }
+    }
+
+    // Helper function to check if node is handled by another visitor
+    function isHandledByOtherVisitor(node) {
+      let parent = node.parent;
+
+      // Check if it's in a binary expression - let BinaryExpression handle it
+      if (parent && parent.type === 'BinaryExpression') {
+        return true;
+      }
+
+      // Check if it's in a variable declaration - let VariableDeclarator handle it
+      while (parent && parent.type !== 'Program') {
+        if (parent.type === 'VariableDeclarator' && parent.init === node) {
+          return true;
+        }
+        parent = parent.parent;
+      }
+
+      return false;
+    }
+
+    // Helper function to check if node is in a read-only context
+    function isInReadOnlyContext(node) {
+      let currentParent = node.parent;
+
+      // Check if it's in console.log() or similar logging
+      if (currentParent && currentParent.type === 'CallExpression' &&
+          currentParent.callee.type === 'MemberExpression' &&
+          currentParent.callee.object.name === 'console') {
+        return true;
+      }
+
+      // Check if it's just a property in an object literal (debug info)
+      if (currentParent && currentParent.type === 'Property' &&
+          currentParent.parent && currentParent.parent.type === 'ObjectExpression') {
+        return true;
+      }
+
+      // Check if it's inside a resize event handler
+      let checkNode = currentParent;
+      while (checkNode) {
+        if (checkNode.type === 'AssignmentExpression' &&
+            checkNode.left.type === 'MemberExpression' &&
+            checkNode.left.object.name === 'window' &&
+            checkNode.left.property.name === 'onresize') {
+          return true;
+        }
+        // Also check for addEventListener('resize', ...)
+        if (checkNode.type === 'CallExpression' &&
+            checkNode.callee.type === 'MemberExpression' &&
+            checkNode.callee.property.name === 'addEventListener' &&
+            checkNode.arguments.length > 0 &&
+            checkNode.arguments[0].type === 'Literal' &&
+            checkNode.arguments[0].value === 'resize') {
+          return true;
+        }
+        checkNode = checkNode.parent;
+      }
+
+      return false;
     }
 
     return {
@@ -193,74 +283,19 @@ module.exports = {
       MemberExpression(node) {
         const viewportInfo = isViewportProperty(node);
         if (viewportInfo) {
-          // Check if this node is already handled by other visitors
-          let parent = node.parent;
-          let isHandledByOtherVisitor = false;
-
-          // Check if it's in a binary expression - let BinaryExpression handle it
-          if (parent && parent.type === 'BinaryExpression') {
-            isHandledByOtherVisitor = true;
+          // Skip if handled by another visitor
+          if (isHandledByOtherVisitor(node)) {
+            return;
           }
 
-          // Check if it's in a variable declaration - let VariableDeclarator handle it
-          while (parent && parent.type !== 'Program') {
-            if (parent.type === 'VariableDeclarator' && parent.init === node) {
-              isHandledByOtherVisitor = true;
-              break;
-            }
-            parent = parent.parent;
+          // Skip if in read-only context
+          if (isInReadOnlyContext(node)) {
+            return;
           }
 
-          if (isHandledByOtherVisitor) {
-            return; // Let other visitor handle this
-          }
-
-          // Check for read-only contexts
-          let currentParent = node.parent;
-          let isReadOnly = false;
-
-          // Check if it's in console.log() or similar logging
-          if (currentParent && currentParent.type === 'CallExpression' &&
-              currentParent.callee.type === 'MemberExpression' &&
-              currentParent.callee.object.name === 'console') {
-            isReadOnly = true;
-          }
-
-          // Check if it's just a property in an object literal (debug info)
-          if (currentParent && currentParent.type === 'Property' &&
-              currentParent.parent && currentParent.parent.type === 'ObjectExpression') {
-            isReadOnly = true;
-          }
-
-          // Check if it's inside a resize event handler (don't double report)
-          let checkNode = currentParent;
-          while (checkNode) {
-            if (checkNode.type === 'AssignmentExpression' &&
-                checkNode.left.type === 'MemberExpression' &&
-                checkNode.left.object.name === 'window' &&
-                checkNode.left.property.name === 'onresize') {
-              isReadOnly = true;
-              break;
-            }
-            // Also check for addEventListener('resize', ...)
-            if (checkNode.type === 'CallExpression' &&
-                checkNode.callee.type === 'MemberExpression' &&
-                checkNode.callee.property.name === 'addEventListener' &&
-                checkNode.arguments.length > 0 &&
-                checkNode.arguments[0].type === 'Literal' &&
-                checkNode.arguments[0].value === 'resize') {
-              isReadOnly = true;
-              break;
-            }
-            checkNode = checkNode.parent;
-          }
-
-          if (!isReadOnly && !isResponsiveTest && (!allowViewportSetup || !hasSetViewport)) {
-            if (viewportInfo.type === 'screen') {
-              reportOnce(node, 'avoidScreenCheck', { property: viewportInfo.property });
-            } else {
-              reportOnce(node, 'avoidViewportCheck', { property: viewportInfo.property });
-            }
+          // Report issue if not in responsive test and viewport not set
+          if (!isResponsiveTest && (!allowViewportSetup || !hasSetViewport)) {
+            reportViewportPropertyIssue(node, viewportInfo);
           }
         }
 
@@ -378,11 +413,13 @@ module.exports = {
           parent = parent.parent;
         }
 
+        // Check both sides for viewport properties
+        const leftInfo = isViewportProperty(left);
+        const rightInfo = isViewportProperty(right);
+
+        // Report issues based on context
         if (isInVariableDeclaration) {
           // In variable declarations, report useFixedViewport for any viewport property
-          const leftInfo = isViewportProperty(left);
-          const rightInfo = isViewportProperty(right);
-
           if (leftInfo && !isResponsiveTest) {
             reportOnce(left, 'useFixedViewport');
           }
@@ -390,23 +427,12 @@ module.exports = {
             reportOnce(right, 'useFixedViewport');
           }
         } else {
-          // In other contexts (like if statements), report appropriate message
-          const leftInfo = isViewportProperty(left);
-          const rightInfo = isViewportProperty(right);
-
-          if (leftInfo && !isResponsiveTest) {
-            if (leftInfo.type === 'screen') {
-              reportOnce(left, 'avoidScreenCheck', { property: leftInfo.property });
-            } else {
-              reportOnce(left, 'avoidViewportCheck', { property: leftInfo.property });
-            }
+          // In other contexts (like if statements), use the standard reporting
+          if (leftInfo) {
+            reportViewportPropertyIssue(left, leftInfo);
           }
-          if (rightInfo && !isResponsiveTest) {
-            if (rightInfo.type === 'screen') {
-              reportOnce(right, 'avoidScreenCheck', { property: rightInfo.property });
-            } else {
-              reportOnce(right, 'avoidViewportCheck', { property: rightInfo.property });
-            }
+          if (rightInfo) {
+            reportViewportPropertyIssue(right, rightInfo);
           }
         }
       },
@@ -415,12 +441,8 @@ module.exports = {
       VariableDeclarator(node) {
         if (node.init) {
           const viewportInfo = isViewportProperty(node.init);
-          if (viewportInfo && !isResponsiveTest) {
-            if (viewportInfo.type === 'screen') {
-              reportOnce(node.init, 'avoidScreenCheck', { property: viewportInfo.property });
-            } else {
-              reportOnce(node.init, 'avoidViewportCheck', { property: viewportInfo.property });
-            }
+          if (viewportInfo) {
+            reportViewportPropertyIssue(node.init, viewportInfo);
           }
         }
       },
@@ -437,19 +459,17 @@ module.exports = {
             const initText = sourceCode.getText(declarator.init);
 
             if (initText === 'window' &&
-                ['innerWidth', 'innerHeight', 'outerWidth', 'outerHeight'].includes(node.key.name)) {
+                VIEWPORT_PROPERTIES.window.includes(node.key.name)) {
               const property = `window.${node.key.name}`;
-              if (!isResponsiveTest) {
-                reportOnce(node, 'avoidViewportCheck', { property });
-              }
+              const viewportInfo = { type: 'viewport', property };
+              reportViewportPropertyIssue(node, viewportInfo);
             }
 
             if (initText === 'screen' &&
-                ['width', 'height', 'availWidth', 'availHeight'].includes(node.key.name)) {
+                VIEWPORT_PROPERTIES.screen.includes(node.key.name)) {
               const property = `screen.${node.key.name}`;
-              if (!isResponsiveTest) {
-                reportOnce(node, 'avoidScreenCheck', { property });
-              }
+              const viewportInfo = { type: 'screen', property };
+              reportViewportPropertyIssue(node, viewportInfo);
             }
           }
         }

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -457,22 +457,23 @@ module.exports = {
           // Check if the value being destructured is a viewport property
           let declarator = node.parent.parent;
           if (declarator && declarator.type === 'VariableDeclarator' && declarator.init) {
-            // Check if we're destructuring from window, screen, etc.
             const sourceCode = context.getSourceCode();
             const initText = sourceCode.getText(declarator.init);
 
-            if (initText === 'window' &&
-                VIEWPORT_PROPERTIES.window.includes(node.key.name)) {
-              const property = `window.${node.key.name}`;
-              const viewportInfo = { type: 'viewport', property };
-              reportViewportPropertyIssue(node, viewportInfo);
-            }
+            // Configuration for destructuring sources
+            const destructuringSources = [
+              { source: 'window', type: 'viewport', properties: VIEWPORT_PROPERTIES.window },
+              { source: 'screen', type: 'screen', properties: VIEWPORT_PROPERTIES.screen }
+            ];
 
-            if (initText === 'screen' &&
-                VIEWPORT_PROPERTIES.screen.includes(node.key.name)) {
-              const property = `screen.${node.key.name}`;
-              const viewportInfo = { type: 'screen', property };
-              reportViewportPropertyIssue(node, viewportInfo);
+            // Check each configured source
+            for (const config of destructuringSources) {
+              if (initText === config.source && config.properties.includes(node.key.name)) {
+                const property = `${config.source}.${node.key.name}`;
+                const viewportInfo = { type: config.type, property };
+                reportViewportPropertyIssue(node, viewportInfo);
+                break;
+              }
             }
           }
         }

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -1,0 +1,423 @@
+/**
+ * @fileoverview Rule to avoid viewport-dependent assertions that may fail on different screen sizes
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const { isTestFile, getFilename } = require('../utils/helpers');
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Avoid viewport-dependent assertions that may fail on different screen sizes',
+      category: 'Best Practices',
+      recommended: false,
+      url: 'https://github.com/tigredonorte/eslint-plugin-test-flakiness/blob/main/docs/rules/no-viewport-dependent.md'
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowViewportSetup: {
+            type: 'boolean',
+            default: true,
+            description: 'Allow viewport configuration in test setup hooks'
+          },
+          allowResponsiveTests: {
+            type: 'boolean',
+            default: false,
+            description: 'Allow tests specifically designed for responsive design testing'
+          },
+          ignoreMediaQueries: {
+            type: 'boolean',
+            default: false,
+            description: 'Ignore tests that specifically test CSS media query behavior'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      avoidViewportCheck: 'Avoid viewport-dependent checks. Tests may fail on different screen sizes. Property: {{property}}',
+      avoidScreenCheck: 'Screen dimension checks can fail on different screen sizes. Property: {{property}}',
+      avoidBoundingRect: 'getBoundingClientRect checks are viewport-dependent',
+      useFixedViewport: 'Set a fixed viewport size before viewport-dependent assertions',
+      avoidResizeListener: 'Resize event listeners are viewport-dependent',
+      setFixedViewport: 'Set a fixed viewport size before viewport-dependent assertions.',
+      avoidMediaQuery: 'Media query checks can fail on different screen sizes.',
+      avoidPositionCheck: 'Position-based assertions are viewport-dependent.',
+      avoidScrollCheck: 'Scroll-based checks depend on viewport size.'
+    }
+  },
+
+  create(context) {
+    const filename = getFilename(context);
+    if (!isTestFile(filename)) {
+      return {};
+    }
+
+    const options = context.options[0] || {};
+    const allowViewportSetup = options.allowViewportSetup !== false;
+    const allowResponsiveTests = options.allowResponsiveTests || false;
+    const ignoreMediaQueries = options.ignoreMediaQueries || false;
+
+    let hasSetViewport = false;
+    const reportedNodes = new Set(); // Track reported nodes to avoid duplicates
+    let isResponsiveTest = false; // Track if this is a responsive test
+
+    function isViewportProperty(node) {
+      if (node.type !== 'MemberExpression') return false;
+
+      // window.innerWidth, window.innerHeight, etc.
+      if (node.object.name === 'window' &&
+          ['innerWidth', 'innerHeight', 'outerWidth', 'outerHeight'].includes(node.property.name)) {
+        return { type: 'viewport', property: `window.${node.property.name}` };
+      }
+
+      // screen.width, screen.height, etc.
+      if (node.object.name === 'screen' &&
+          ['width', 'height', 'availWidth', 'availHeight'].includes(node.property.name)) {
+        return { type: 'screen', property: `screen.${node.property.name}` };
+      }
+
+      // visualViewport.width, visualViewport.height
+      if (node.object.name === 'visualViewport' &&
+          ['width', 'height'].includes(node.property.name)) {
+        return { type: 'viewport', property: `visualViewport.${node.property.name}` };
+      }
+
+      // document.documentElement.clientWidth, etc.
+      if (node.object.type === 'MemberExpression' &&
+          node.object.object.name === 'document' &&
+          node.object.property.name === 'documentElement' &&
+          ['clientWidth', 'clientHeight'].includes(node.property.name)) {
+        return { type: 'viewport', property: `document.documentElement.${node.property.name}` };
+      }
+
+      // document.body.clientWidth, etc.
+      if (node.object.type === 'MemberExpression' &&
+          node.object.object.name === 'document' &&
+          node.object.property.name === 'body' &&
+          ['clientWidth', 'clientHeight', 'offsetWidth', 'offsetHeight'].includes(node.property.name)) {
+        return { type: 'viewport', property: `document.body.${node.property.name}` };
+      }
+
+      return false;
+    }
+
+    function isScrollProperty(node) {
+      if (node.type !== 'MemberExpression') return false;
+
+      // window.scrollY, window.pageYOffset, etc.
+      if (node.object.name === 'window' &&
+          ['scrollY', 'scrollX', 'pageYOffset', 'pageXOffset'].includes(node.property.name)) {
+        return true;
+      }
+
+      // Generic scroll properties (but allow mock objects)
+      if (['scrollTop', 'scrollLeft', 'scrollHeight', 'scrollWidth'].includes(node.property.name)) {
+        const sourceCode = context.getSourceCode();
+        const objectText = sourceCode.getText(node.object);
+
+        // Don't flag clearly mock objects or element properties
+        if (/mock|stub|spy|div\.|element|container|node|target/.test(objectText)) {
+          return false;
+        }
+        return true;
+      }
+
+      return false;
+    }
+
+    function reportOnce(node, messageId, data) {
+      const nodeKey = `${node.range[0]}-${node.range[1]}`;
+      if (!reportedNodes.has(nodeKey)) {
+        reportedNodes.add(nodeKey);
+        context.report({
+          node,
+          messageId,
+          data
+        });
+      }
+    }
+
+    return {
+      // Check for responsive test context at the start
+      Program(_node) {
+        const sourceCode = context.getSourceCode();
+        const text = sourceCode.getText();
+        // Check if file has responsive test indicators
+        if (allowResponsiveTests) {
+          isResponsiveTest = /describe.*['"`](.*responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i.test(text);
+        }
+      },
+
+      // Handle member expressions (property access)
+      MemberExpression(node) {
+        const viewportInfo = isViewportProperty(node);
+        if (viewportInfo) {
+          // Check if this node is already handled by other visitors
+          let parent = node.parent;
+          let isHandledByOtherVisitor = false;
+
+          // Check if it's in a binary expression - let BinaryExpression handle it
+          if (parent && parent.type === 'BinaryExpression') {
+            isHandledByOtherVisitor = true;
+          }
+
+          // Check if it's in a variable declaration - let VariableDeclarator handle it
+          while (parent && parent.type !== 'Program') {
+            if (parent.type === 'VariableDeclarator' && parent.init === node) {
+              isHandledByOtherVisitor = true;
+              break;
+            }
+            parent = parent.parent;
+          }
+
+          if (isHandledByOtherVisitor) {
+            return; // Let other visitor handle this
+          }
+
+          // Check for read-only contexts
+          let currentParent = node.parent;
+          let isReadOnly = false;
+
+          // Check if it's in console.log() or similar logging
+          if (currentParent && currentParent.type === 'CallExpression' &&
+              currentParent.callee.type === 'MemberExpression' &&
+              currentParent.callee.object.name === 'console') {
+            isReadOnly = true;
+          }
+
+          // Check if it's just a property in an object literal (debug info)
+          if (currentParent && currentParent.type === 'Property' &&
+              currentParent.parent && currentParent.parent.type === 'ObjectExpression') {
+            isReadOnly = true;
+          }
+
+          // Check if it's inside a resize event handler (don't double report)
+          let checkNode = currentParent;
+          while (checkNode) {
+            if (checkNode.type === 'AssignmentExpression' &&
+                checkNode.left.type === 'MemberExpression' &&
+                checkNode.left.object.name === 'window' &&
+                checkNode.left.property.name === 'onresize') {
+              isReadOnly = true;
+              break;
+            }
+            // Also check for addEventListener('resize', ...)
+            if (checkNode.type === 'CallExpression' &&
+                checkNode.callee.type === 'MemberExpression' &&
+                checkNode.callee.property.name === 'addEventListener' &&
+                checkNode.arguments.length > 0 &&
+                checkNode.arguments[0].type === 'Literal' &&
+                checkNode.arguments[0].value === 'resize') {
+              isReadOnly = true;
+              break;
+            }
+            checkNode = checkNode.parent;
+          }
+
+          if (!isReadOnly && !isResponsiveTest && (!allowViewportSetup || !hasSetViewport)) {
+            if (viewportInfo.type === 'screen') {
+              reportOnce(node, 'avoidScreenCheck', { property: viewportInfo.property });
+            } else {
+              reportOnce(node, 'avoidViewportCheck', { property: viewportInfo.property });
+            }
+          }
+        }
+
+        // Handle scroll properties but avoid flagging element properties
+        if (isScrollProperty(node)) {
+          const sourceCode = context.getSourceCode();
+          const objectText = sourceCode.getText(node.object);
+
+          // Only flag if it doesn't look like a specific element property
+          // Allow: div.scrollWidth, element.scrollTop, container.scrollLeft, etc.
+          if (!isResponsiveTest && !/^(div|element|container|node|target|mock|stub|spy)\b/i.test(objectText)) {
+            reportOnce(node, 'avoidScrollCheck');
+          }
+        }
+      },
+
+      // Handle function calls
+      CallExpression(node) {
+        const callee = node.callee;
+
+        // Check viewport setup calls
+        if (callee.type === 'MemberExpression') {
+          const method = callee.property.name;
+
+          // Playwright: page.setViewportSize
+          if (method === 'setViewportSize' || method === 'setViewport') {
+            hasSetViewport = true;
+            return;
+          }
+
+          // Cypress: cy.viewport
+          if (callee.object.name === 'cy' && method === 'viewport') {
+            hasSetViewport = true;
+            return;
+          }
+
+          // window.matchMedia
+          if (callee.object.name === 'window' && method === 'matchMedia') {
+            if (!ignoreMediaQueries && !isResponsiveTest) {
+              reportOnce(node, 'avoidViewportCheck', { property: 'window.matchMedia' });
+            }
+            return;
+          }
+
+          // getBoundingClientRect on viewport elements
+          if (method === 'getBoundingClientRect') {
+            const objText = context.getSourceCode().getText(callee.object);
+            if (!isResponsiveTest && (objText.includes('document.documentElement') || objText.includes('document.body'))) {
+              reportOnce(node, 'avoidBoundingRect');
+            }
+          }
+
+          // addEventListener for resize
+          if (method === 'addEventListener' &&
+              node.arguments.length > 0 &&
+              node.arguments[0].type === 'Literal' &&
+              node.arguments[0].value === 'resize') {
+            if (!isResponsiveTest) {
+              reportOnce(node, 'avoidResizeListener');
+            }
+          }
+        }
+      },
+
+      // Handle new expressions
+      NewExpression(node) {
+        if (node.callee.name === 'ResizeObserver') {
+          if (!isResponsiveTest) {
+            reportOnce(node, 'avoidViewportCheck', { property: 'ResizeObserver' });
+          }
+        }
+
+        if (node.callee.name === 'IntersectionObserver') {
+          if (!isResponsiveTest && (!allowViewportSetup || !hasSetViewport)) {
+            reportOnce(node, 'avoidViewportCheck', { property: 'viewport-IntersectionObserver' });
+          }
+        }
+      },
+
+      // Handle assignment expressions (window.onresize = ...)
+      AssignmentExpression(node) {
+        if (node.left.type === 'MemberExpression' &&
+            node.left.object.name === 'window' &&
+            node.left.property.name === 'onresize') {
+          if (!isResponsiveTest) {
+            reportOnce(node, 'avoidResizeListener');
+          }
+        }
+      },
+
+      // Handle binary expressions for responsive breakpoint checks
+      BinaryExpression(node) {
+        const left = node.left;
+        const right = node.right;
+
+        // Check if we're in a variable declaration context (which expects useFixedViewport)
+        let isInVariableDeclaration = false;
+        let parent = node.parent;
+        while (parent) {
+          if (parent.type === 'VariableDeclarator') {
+            isInVariableDeclaration = true;
+            break;
+          }
+          if (parent.type === 'FunctionDeclaration' || parent.type === 'FunctionExpression') {
+            break;
+          }
+          parent = parent.parent;
+        }
+
+        if (isInVariableDeclaration) {
+          // In variable declarations, report useFixedViewport for any viewport property
+          const leftInfo = isViewportProperty(left);
+          const rightInfo = isViewportProperty(right);
+
+          if (leftInfo && !isResponsiveTest) {
+            reportOnce(left, 'useFixedViewport');
+          }
+          if (rightInfo && !isResponsiveTest) {
+            reportOnce(right, 'useFixedViewport');
+          }
+        } else {
+          // In other contexts (like if statements), report appropriate message
+          const leftInfo = isViewportProperty(left);
+          const rightInfo = isViewportProperty(right);
+
+          if (leftInfo && !isResponsiveTest) {
+            if (leftInfo.type === 'screen') {
+              reportOnce(left, 'avoidScreenCheck', { property: leftInfo.property });
+            } else {
+              reportOnce(left, 'avoidViewportCheck', { property: leftInfo.property });
+            }
+          }
+          if (rightInfo && !isResponsiveTest) {
+            if (rightInfo.type === 'screen') {
+              reportOnce(right, 'avoidScreenCheck', { property: rightInfo.property });
+            } else {
+              reportOnce(right, 'avoidViewportCheck', { property: rightInfo.property });
+            }
+          }
+        }
+      },
+
+      // Handle variable declarations
+      VariableDeclarator(node) {
+        if (node.init) {
+          const viewportInfo = isViewportProperty(node.init);
+          if (viewportInfo && !isResponsiveTest) {
+            if (viewportInfo.type === 'screen') {
+              reportOnce(node.init, 'avoidScreenCheck', { property: viewportInfo.property });
+            } else {
+              reportOnce(node.init, 'avoidViewportCheck', { property: viewportInfo.property });
+            }
+          }
+        }
+      },
+
+      // Handle property access in variable patterns (destructuring)
+      Property(node) {
+        // Only handle if this is part of a destructuring pattern
+        if (node.parent && node.parent.type === 'ObjectPattern') {
+          // Check if the value being destructured is a viewport property
+          let declarator = node.parent.parent;
+          if (declarator && declarator.type === 'VariableDeclarator' && declarator.init) {
+            // Check if we're destructuring from window, screen, etc.
+            const sourceCode = context.getSourceCode();
+            const initText = sourceCode.getText(declarator.init);
+
+            if (initText === 'window' &&
+                ['innerWidth', 'innerHeight', 'outerWidth', 'outerHeight'].includes(node.key.name)) {
+              const property = `window.${node.key.name}`;
+              if (!isResponsiveTest) {
+                reportOnce(node, 'avoidViewportCheck', { property });
+              }
+            }
+
+            if (initText === 'screen' &&
+                ['width', 'height', 'availWidth', 'availHeight'].includes(node.key.name)) {
+              const property = `screen.${node.key.name}`;
+              if (!isResponsiveTest) {
+                reportOnce(node, 'avoidScreenCheck', { property });
+              }
+            }
+          }
+        }
+      },
+
+      'Program:exit'() {
+        // Reset for next file
+        hasSetViewport = false;
+        reportedNodes.clear();
+        isResponsiveTest = false;
+      }
+    };
+  }
+};

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -25,8 +25,10 @@ const VIEWPORT_PROPERTIES = {
 const WINDOW_SCROLL_PROPERTIES = ['scrollY', 'scrollX', 'pageYOffset', 'pageXOffset'];
 const ELEMENT_SCROLL_PROPERTIES = ['scrollTop', 'scrollLeft', 'scrollHeight', 'scrollWidth'];
 
-// Pattern for detecting responsive test contexts
-const RESPONSIVE_TEST_PATTERN = /describe.*['"`](?:.*?responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i;
+// Pattern for detecting responsive test contexts in test descriptions
+// Matches describe() or it() calls with strings containing responsive-related keywords
+// Note: This is applied to the full file text, so it may match in comments
+const RESPONSIVE_TEST_PATTERN = /(?:describe|it|test)\s*\(\s*['"`](?:[^'"`\\]|\\.)*\b(?:responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*sizes?|media\s*quer(?:y|ies))\b/i;
 
 module.exports = {
   meta: {

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -10,7 +10,7 @@ const { isTestFile, getFilename } = require('../utils/helpers');
 const ALLOWED_MOCK_ELEMENT_NAMES = ['mock', 'stub', 'spy', 'element', 'container', 'node', 'target', 'div'];
 
 // Pattern for detecting responsive test contexts
-const RESPONSIVE_TEST_PATTERN = /describe.*['"`](.*responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i;
+const RESPONSIVE_TEST_PATTERN = /describe.*['"`](?:.*responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i;
 
 module.exports = {
   meta: {
@@ -73,6 +73,13 @@ module.exports = {
     let hasSetViewport;
     let reportedNodes;
     let isResponsiveTest;
+
+    // Helper function to check if a node is a function node
+    function isFunctionNode(node) {
+      return node.type === 'FunctionDeclaration' ||
+             node.type === 'FunctionExpression' ||
+             node.type === 'ArrowFunctionExpression';
+    }
 
     // Helper function to consistently check for mock objects and DOM elements
     function isMockOrElementObject(node) {
@@ -144,10 +151,10 @@ module.exports = {
         return true;
       }
 
-      // Generic scroll properties (but allow mock objects)
+      // Generic scroll properties
       if (['scrollTop', 'scrollLeft', 'scrollHeight', 'scrollWidth'].includes(node.property.name)) {
-        // We return true here only if it's a generic scroll property
-        // The caller should check if it's a mock object separately
+        // Returns true for any element with scroll properties.
+        // The caller is responsible for context-specific filtering (e.g., mock objects vs. real DOM elements).
         return true;
       }
 
@@ -365,11 +372,7 @@ module.exports = {
             isInVariableDeclaration = true;
             break;
           }
-          if (
-            parent.type === 'FunctionDeclaration' ||
-            parent.type === 'FunctionExpression' ||
-            parent.type === 'ArrowFunctionExpression'
-          ) {
+          if (isFunctionNode(parent)) {
             break;
           }
           parent = parent.parent;

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -202,13 +202,14 @@ module.exports = {
 
     // Helper function to report viewport property issues
     function reportViewportPropertyIssue(node, viewportInfo) {
-      if (!isResponsiveTest) {
-        if (viewportInfo.type === 'screen') {
-          reportOnce(node, 'avoidScreenCheck', { property: viewportInfo.property });
-        } else {
-          reportOnce(node, 'avoidViewportCheck', { property: viewportInfo.property });
-        }
+      if (isResponsiveTest) return;
+
+      if (viewportInfo.type === 'screen') {
+        reportOnce(node, 'avoidScreenCheck', { property: viewportInfo.property });
+        return;
       }
+
+      reportOnce(node, 'avoidViewportCheck', { property: viewportInfo.property });
     }
 
     // Helper function to check if node is handled by another visitor
@@ -293,25 +294,23 @@ module.exports = {
         const viewportInfo = isViewportProperty(node);
         if (viewportInfo) {
           // Skip if handled by another visitor
-          if (isHandledByOtherVisitor(node)) {
-            return;
-          }
+          if (isHandledByOtherVisitor(node)) return;
 
           // Skip if in read-only context
-          if (isInReadOnlyContext(node)) {
-            return;
-          }
+          if (isInReadOnlyContext(node)) return;
 
           // Report issue if not in responsive test and viewport not set
           if (!isResponsiveTest && (!allowViewportSetup || !hasSetViewport)) {
             reportViewportPropertyIssue(node, viewportInfo);
           }
+          return;
         }
 
         // Handle scroll properties (filtering is done inside isScrollProperty)
-        if (isScrollProperty(node) && !isResponsiveTest) {
-          reportOnce(node, 'avoidScrollCheck');
-        }
+        if (!isScrollProperty(node)) return;
+        if (isResponsiveTest) return;
+
+        reportOnce(node, 'avoidScrollCheck');
       },
 
       // Handle function calls
@@ -326,85 +325,91 @@ module.exports = {
           return;
         }
 
-        // Check viewport setup calls
-        if (callee.type === 'MemberExpression') {
-          const method = callee.property.name;
+        // Only process MemberExpression callees
+        if (callee.type !== 'MemberExpression') return;
 
-          // Playwright: page.setViewportSize
-          if (method === 'setViewportSize' || method === 'setViewport') {
-            hasSetViewport = true;
-            return;
-          }
+        const method = callee.property.name;
 
-          // Cypress: cy.viewport
-          if (callee.object.name === 'cy' && method === 'viewport') {
-            hasSetViewport = true;
-            return;
-          }
-
-          // window.matchMedia
-          if (callee.object.name === 'window' && method === 'matchMedia') {
-            if (!ignoreMediaQueries && !isResponsiveTest) {
-              reportOnce(node, 'avoidViewportCheck', { property: 'window.matchMedia' });
-            }
-            return;
-          }
-
-          // getBoundingClientRect on viewport elements
-          if (method === 'getBoundingClientRect') {
-            // Check AST structure directly for document.documentElement or document.body
-            const obj = callee.object;
-            const isViewportElement = obj.type === 'MemberExpression' &&
-                                     obj.object.name === 'document' &&
-                                     (obj.property.name === 'documentElement' || obj.property.name === 'body');
-
-            if (!isResponsiveTest && isViewportElement) {
-              reportOnce(node, 'avoidBoundingRect');
-            }
-          }
-
-          // addEventListener for resize
-          if (method === 'addEventListener' &&
-              node.arguments.length > 0 &&
-              node.arguments[0].type === 'Literal' &&
-              node.arguments[0].value === 'resize') {
-            if (!isResponsiveTest) {
-              reportOnce(node, 'avoidResizeListener');
-            }
-          }
+        // Playwright: page.setViewportSize
+        if (method === 'setViewportSize' || method === 'setViewport') {
+          hasSetViewport = true;
+          return;
         }
+
+        // Cypress: cy.viewport
+        if (callee.object.name === 'cy' && method === 'viewport') {
+          hasSetViewport = true;
+          return;
+        }
+
+        // window.matchMedia
+        if (callee.object.name === 'window' && method === 'matchMedia') {
+          if (!ignoreMediaQueries && !isResponsiveTest) {
+            reportOnce(node, 'avoidViewportCheck', { property: 'window.matchMedia' });
+          }
+          return;
+        }
+
+        // getBoundingClientRect on viewport elements
+        if (method === 'getBoundingClientRect') {
+          // Check AST structure directly for document.documentElement or document.body
+          const obj = callee.object;
+          const isViewportElement = obj.type === 'MemberExpression' &&
+                                   obj.object.name === 'document' &&
+                                   (obj.property.name === 'documentElement' || obj.property.name === 'body');
+
+          if (isResponsiveTest || !isViewportElement) return;
+
+          reportOnce(node, 'avoidBoundingRect');
+          return;
+        }
+
+        // addEventListener for resize
+        if (method !== 'addEventListener') return;
+        if (node.arguments.length === 0) return;
+        if (node.arguments[0].type !== 'Literal') return;
+        if (node.arguments[0].value !== 'resize') return;
+        if (isResponsiveTest) return;
+
+        reportOnce(node, 'avoidResizeListener');
       },
 
       // Handle new expressions
       NewExpression(node) {
         if (node.callee.name === 'ResizeObserver') {
-          if (!isResponsiveTest) {
-            reportOnce(node, 'avoidViewportCheck', { property: 'ResizeObserver' });
-          }
+          if (isResponsiveTest) return;
+          reportOnce(node, 'avoidViewportCheck', { property: 'ResizeObserver' });
+          return;
         }
 
         if (node.callee.name === 'IntersectionObserver') {
-          if (!isResponsiveTest && (!allowViewportSetup || !hasSetViewport)) {
-            reportOnce(node, 'avoidViewportCheck', { property: 'viewport-IntersectionObserver' });
-          }
+          if (isResponsiveTest) return;
+          if (allowViewportSetup && hasSetViewport) return;
+          reportOnce(node, 'avoidViewportCheck', { property: 'viewport-IntersectionObserver' });
         }
       },
 
       // Handle assignment expressions (window.onresize = ...)
       AssignmentExpression(node) {
-        if (node.left.type === 'MemberExpression' &&
-            node.left.object.name === 'window' &&
-            node.left.property.name === 'onresize') {
-          if (!isResponsiveTest) {
-            reportOnce(node, 'avoidResizeListener');
-          }
-        }
+        if (node.left.type !== 'MemberExpression') return;
+        if (node.left.object.name !== 'window') return;
+        if (node.left.property.name !== 'onresize') return;
+        if (isResponsiveTest) return;
+
+        reportOnce(node, 'avoidResizeListener');
       },
 
       // Handle binary expressions for responsive breakpoint checks
       BinaryExpression(node) {
         const left = node.left;
         const right = node.right;
+
+        // Check both sides for viewport properties
+        const leftInfo = isViewportProperty(left);
+        const rightInfo = isViewportProperty(right);
+
+        // Early return if no viewport properties
+        if (!leftInfo && !rightInfo) return;
 
         // Check if we're in a variable declaration context (which expects useFixedViewport)
         let isInVariableDeclaration = false;
@@ -420,10 +425,6 @@ module.exports = {
           parent = parent.parent;
         }
 
-        // Check both sides for viewport properties
-        const leftInfo = isViewportProperty(left);
-        const rightInfo = isViewportProperty(right);
-
         // Report issues based on context
         if (isInVariableDeclaration) {
           // In variable declarations, report useFixedViewport for any viewport property
@@ -433,55 +434,57 @@ module.exports = {
           if (rightInfo && !isResponsiveTest) {
             reportOnce(right, 'useFixedViewport');
           }
-        } else {
-          // In other contexts (like if statements), use the standard reporting
-          if (leftInfo) {
-            reportViewportPropertyIssue(left, leftInfo);
-          }
-          if (rightInfo) {
-            reportViewportPropertyIssue(right, rightInfo);
-          }
+          return;
+        }
+
+        // In other contexts (like if statements), use the standard reporting
+        if (leftInfo) {
+          reportViewportPropertyIssue(left, leftInfo);
+        }
+        if (rightInfo) {
+          reportViewportPropertyIssue(right, rightInfo);
         }
       },
 
       // Handle variable declarations
       VariableDeclarator(node) {
-        if (node.init) {
-          const viewportInfo = isViewportProperty(node.init);
-          if (viewportInfo) {
-            reportViewportPropertyIssue(node.init, viewportInfo);
-          }
-        }
+        if (!node.init) return;
+
+        const viewportInfo = isViewportProperty(node.init);
+        if (!viewportInfo) return;
+
+        reportViewportPropertyIssue(node.init, viewportInfo);
       },
 
       // Handle property access in variable patterns (destructuring)
       Property(node) {
         // Only handle if this is part of a destructuring pattern
-        if (node.parent && node.parent.type === 'ObjectPattern') {
-          // Check if the value being destructured is a viewport property
-          let declarator = node.parent.parent;
-          if (declarator && declarator.type === 'VariableDeclarator' && declarator.init) {
-            // Check AST structure directly instead of using getText()
-            const init = declarator.init;
+        if (!node.parent || node.parent.type !== 'ObjectPattern') return;
 
-            // Only handle simple identifiers (window, screen)
-            if (init.type === 'Identifier') {
-              // Configuration for destructuring sources
-              const destructuringSources = [
-                { source: 'window', type: 'viewport', properties: VIEWPORT_PROPERTIES.window },
-                { source: 'screen', type: 'screen', properties: VIEWPORT_PROPERTIES.screen }
-              ];
+        // Check if the value being destructured is a viewport property
+        let declarator = node.parent.parent;
+        if (!declarator || declarator.type !== 'VariableDeclarator') return;
+        if (!declarator.init) return;
 
-              // Check each configured source
-              for (const config of destructuringSources) {
-                if (init.name === config.source && config.properties.includes(node.key.name)) {
-                  const property = `${config.source}.${node.key.name}`;
-                  const viewportInfo = { type: config.type, property };
-                  reportViewportPropertyIssue(node, viewportInfo);
-                  break;
-                }
-              }
-            }
+        // Check AST structure directly instead of using getText()
+        const init = declarator.init;
+
+        // Only handle simple identifiers (window, screen)
+        if (init.type !== 'Identifier') return;
+
+        // Configuration for destructuring sources
+        const destructuringSources = [
+          { source: 'window', type: 'viewport', properties: VIEWPORT_PROPERTIES.window },
+          { source: 'screen', type: 'screen', properties: VIEWPORT_PROPERTIES.screen }
+        ];
+
+        // Check each configured source
+        for (const config of destructuringSources) {
+          if (init.name === config.source && config.properties.includes(node.key.name)) {
+            const property = `${config.source}.${node.key.name}`;
+            const viewportInfo = { type: config.type, property };
+            reportViewportPropertyIssue(node, viewportInfo);
+            break;
           }
         }
       }

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -172,17 +172,18 @@ module.exports = {
         return true;
       }
 
-      // Element scroll properties - filter out mock objects and known DOM elements
-      if (ELEMENT_SCROLL_PROPERTIES.includes(node.property.name)) {
-        // Skip if it's a mock object or known DOM element variable
-        if (isMockOrElementObject(node.object)) {
-          return false;
-        }
-        // Report scroll properties on non-mock objects
-        return true;
+      // Not a scroll property at all
+      if (!ELEMENT_SCROLL_PROPERTIES.includes(node.property.name)) {
+        return false;
       }
 
-      return false;
+      // Element scroll property - skip if it's a mock object or known DOM element
+      if (isMockOrElementObject(node.object)) {
+        return false;
+      }
+
+      // Report scroll properties on non-mock objects
+      return true;
     }
 
     function reportOnce(node, messageId, data) {

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -71,10 +71,11 @@ module.exports = {
     // Helper function to consistently check for mock objects and DOM elements
     function isMockOrElementObject(objectText) {
       const allowedNames = ['mock', 'stub', 'spy', 'element', 'container', 'node', 'target', 'div'];
-      // Check for exact identifier matches or property access patterns
+      // Check for names at start of identifier or property access patterns
       return allowedNames.some(name => {
-        // Check for exact identifier name or property access like "div." or "element."
-        return new RegExp(`^${name}(\\.|$)`, 'i').test(objectText) || objectText.toLowerCase() === name;
+        // Check for name at start of identifier (e.g., mockElement, stubObject)
+        // or exact match, or property access (e.g., div.something)
+        return new RegExp(`^${name}`, 'i').test(objectText) || objectText.toLowerCase() === name;
       });
     }
 
@@ -129,13 +130,8 @@ module.exports = {
 
       // Generic scroll properties (but allow mock objects)
       if (['scrollTop', 'scrollLeft', 'scrollHeight', 'scrollWidth'].includes(node.property.name)) {
-        const sourceCode = context.getSourceCode();
-        const objectText = sourceCode.getText(node.object);
-
-        // Don't flag clearly mock objects or element properties
-        if (isMockOrElementObject(objectText)) {
-          return false;
-        }
+        // We return true here only if it's a generic scroll property
+        // The caller should check if it's a mock object separately
         return true;
       }
 
@@ -249,10 +245,11 @@ module.exports = {
         if (isScrollProperty(node)) {
           const sourceCode = context.getSourceCode();
           const objectText = sourceCode.getText(node.object);
+          const isMockOrElement = isMockOrElementObject(objectText);
 
           // Only flag if it doesn't look like a specific element property
           // Allow: div.scrollWidth, element.scrollTop, container.scrollLeft, etc.
-          if (!isResponsiveTest && !isMockOrElementObject(objectText)) {
+          if (!isResponsiveTest && !isMockOrElement) {
             reportOnce(node, 'avoidScrollCheck');
           }
         }

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -9,6 +9,9 @@ const { isTestFile, getFilename } = require('../utils/helpers');
 // Constants for allowed mock and DOM element names
 const ALLOWED_MOCK_ELEMENT_NAMES = ['mock', 'stub', 'spy', 'element', 'container', 'node', 'target', 'div'];
 
+// Maximum length for suffix in mock/element names to avoid false positives
+const MAX_MOCK_NAME_SUFFIX_LENGTH = 10;
+
 // Constants for viewport properties
 const VIEWPORT_PROPERTIES = {
   window: ['innerWidth', 'innerHeight', 'outerWidth', 'outerHeight'],
@@ -23,7 +26,7 @@ const WINDOW_SCROLL_PROPERTIES = ['scrollY', 'scrollX', 'pageYOffset', 'pageXOff
 const ELEMENT_SCROLL_PROPERTIES = ['scrollTop', 'scrollLeft', 'scrollHeight', 'scrollWidth'];
 
 // Pattern for detecting responsive test contexts
-const RESPONSIVE_TEST_PATTERN = /describe.*['"`](?:.*responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i;
+const RESPONSIVE_TEST_PATTERN = /describe.*['"`](?:.*?responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i;
 
 module.exports = {
   meta: {
@@ -103,7 +106,7 @@ module.exports = {
           // Common patterns: mockElement, stubElement, etc.
           if (name === `${allowed}element` || name === `${allowed}object`) return true;
           // Check if it's a variable like mockDiv, stubContainer (limit suffix length to avoid false positives)
-          return name.startsWith(allowed) && name.length <= allowed.length + 10;
+          return name.startsWith(allowed) && name.length <= allowed.length + MAX_MOCK_NAME_SUFFIX_LENGTH;
         });
       }
 
@@ -113,7 +116,7 @@ module.exports = {
         return ALLOWED_MOCK_ELEMENT_NAMES.some(allowed => {
           if (objName === allowed) return true;
           if (objName === `${allowed}element` || objName === `${allowed}object`) return true;
-          return objName.startsWith(allowed) && objName.length <= allowed.length + 10;
+          return objName.startsWith(allowed) && objName.length <= allowed.length + MAX_MOCK_NAME_SUFFIX_LENGTH;
         });
       }
 
@@ -171,8 +174,8 @@ module.exports = {
 
       // Generic scroll properties
       if (ELEMENT_SCROLL_PROPERTIES.includes(node.property.name)) {
-        // Returns true for any element with scroll properties.
-        // The caller is responsible for context-specific filtering (e.g., mock objects vs. real DOM elements).
+        // Returns true for any scroll property on any object.
+        // Caller must handle context-specific filtering (mock objects, DOM elements, etc.)
         return true;
       }
 

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -6,6 +6,12 @@
 
 const { isTestFile, getFilename } = require('../utils/helpers');
 
+// Constants for allowed mock and DOM element names
+const ALLOWED_MOCK_ELEMENT_NAMES = ['mock', 'stub', 'spy', 'element', 'container', 'node', 'target', 'div'];
+
+// Pattern for detecting responsive test contexts
+const RESPONSIVE_TEST_PATTERN = /describe.*['"`](.*responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i;
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -70,12 +76,10 @@ module.exports = {
 
     // Helper function to consistently check for mock objects and DOM elements
     function isMockOrElementObject(node) {
-      const allowedNames = ['mock', 'stub', 'spy', 'element', 'container', 'node', 'target', 'div'];
-
       // For simple identifiers, check exact match or starts with allowed name
       if (node.type === 'Identifier') {
         const name = node.name.toLowerCase();
-        return allowedNames.some(allowed =>
+        return ALLOWED_MOCK_ELEMENT_NAMES.some(allowed =>
           name === allowed || name.startsWith(allowed)
         );
       }
@@ -83,7 +87,7 @@ module.exports = {
       // For member expressions, check the object name
       if (node.type === 'MemberExpression' && node.object.type === 'Identifier') {
         const objName = node.object.name.toLowerCase();
-        return allowedNames.some(allowed =>
+        return ALLOWED_MOCK_ELEMENT_NAMES.some(allowed =>
           objName === allowed || objName.startsWith(allowed)
         );
       }
@@ -174,7 +178,7 @@ module.exports = {
         const text = sourceCode.getText();
         // Check if file has responsive test indicators
         if (allowResponsiveTests) {
-          isResponsiveTest = /describe.*['"`](.*responsive|viewport|breakpoint|mobile|tablet|desktop|screen\s*size|media\s*query)/i.test(text);
+          isResponsiveTest = RESPONSIVE_TEST_PATTERN.test(text);
         }
       },
 
@@ -361,7 +365,11 @@ module.exports = {
             isInVariableDeclaration = true;
             break;
           }
-          if (parent.type === 'FunctionDeclaration' || parent.type === 'FunctionExpression') {
+          if (
+            parent.type === 'FunctionDeclaration' ||
+            parent.type === 'FunctionExpression' ||
+            parent.type === 'ArrowFunctionExpression'
+          ) {
             break;
           }
           parent = parent.parent;
@@ -442,11 +450,6 @@ module.exports = {
             }
           }
         }
-      },
-
-      'Program:exit'() {
-        // State variables are already initialized per file in Program handler
-        // No need to explicitly reset here
       }
     };
   }

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -350,8 +350,13 @@ module.exports = {
 
           // getBoundingClientRect on viewport elements
           if (method === 'getBoundingClientRect') {
-            const objText = context.getSourceCode().getText(callee.object);
-            if (!isResponsiveTest && (objText.includes('document.documentElement') || objText.includes('document.body'))) {
+            // Check AST structure directly for document.documentElement or document.body
+            const obj = callee.object;
+            const isViewportElement = obj.type === 'MemberExpression' &&
+                                     obj.object.name === 'document' &&
+                                     (obj.property.name === 'documentElement' || obj.property.name === 'body');
+
+            if (!isResponsiveTest && isViewportElement) {
               reportOnce(node, 'avoidBoundingRect');
             }
           }
@@ -454,22 +459,25 @@ module.exports = {
           // Check if the value being destructured is a viewport property
           let declarator = node.parent.parent;
           if (declarator && declarator.type === 'VariableDeclarator' && declarator.init) {
-            const sourceCode = context.getSourceCode();
-            const initText = sourceCode.getText(declarator.init);
+            // Check AST structure directly instead of using getText()
+            const init = declarator.init;
 
-            // Configuration for destructuring sources
-            const destructuringSources = [
-              { source: 'window', type: 'viewport', properties: VIEWPORT_PROPERTIES.window },
-              { source: 'screen', type: 'screen', properties: VIEWPORT_PROPERTIES.screen }
-            ];
+            // Only handle simple identifiers (window, screen)
+            if (init.type === 'Identifier') {
+              // Configuration for destructuring sources
+              const destructuringSources = [
+                { source: 'window', type: 'viewport', properties: VIEWPORT_PROPERTIES.window },
+                { source: 'screen', type: 'screen', properties: VIEWPORT_PROPERTIES.screen }
+              ];
 
-            // Check each configured source
-            for (const config of destructuringSources) {
-              if (initText === config.source && config.properties.includes(node.key.name)) {
-                const property = `${config.source}.${node.key.name}`;
-                const viewportInfo = { type: config.type, property };
-                reportViewportPropertyIssue(node, viewportInfo);
-                break;
+              // Check each configured source
+              for (const config of destructuringSources) {
+                if (init.name === config.source && config.properties.includes(node.key.name)) {
+                  const property = `${config.source}.${node.key.name}`;
+                  const viewportInfo = { type: config.type, property };
+                  reportViewportPropertyIssue(node, viewportInfo);
+                  break;
+                }
               }
             }
           }

--- a/lib/rules/no-viewport-dependent.js
+++ b/lib/rules/no-viewport-dependent.js
@@ -259,6 +259,14 @@ module.exports = {
       CallExpression(node) {
         const callee = node.callee;
 
+        // Check for global matchMedia (without window prefix)
+        if (callee.type === 'Identifier' && callee.name === 'matchMedia') {
+          if (!ignoreMediaQueries && !isResponsiveTest) {
+            reportOnce(node, 'avoidViewportCheck', { property: 'matchMedia' });
+          }
+          return;
+        }
+
         // Check viewport setup calls
         if (callee.type === 'MemberExpression') {
           const method = callee.property.name;

--- a/tests/lib/rules/no-viewport-dependent.test.js
+++ b/tests/lib/rules/no-viewport-dependent.test.js
@@ -89,9 +89,8 @@ ruleTester.run('no-viewport-dependent', rule, {
       filename: 'Debug.test.js'
     },
 
-    // Tests with allowViewportSetup: true and viewport is set
-    // Note: These still report errors because hasSetViewport is evaluated after the checks
-    // This is expected behavior - viewport should be set in beforeEach/setup hooks
+    // Tests with allowViewportSetup: true and explicit viewport setting are considered valid.
+    // This is expected behavior when the viewport is set in the test body.
     {
       code: `
         page.setViewport({ width: 1024, height: 768 });
@@ -127,7 +126,6 @@ ruleTester.run('no-viewport-dependent', rule, {
       filename: 'MobileViewport.test.js',
       options: [{ allowResponsiveTests: true }]
     },
-    // These test names don't contain responsive keywords so they won't be detected as responsive tests
 
     // Tests with ignoreMediaQueries: true
     {

--- a/tests/lib/rules/no-viewport-dependent.test.js
+++ b/tests/lib/rules/no-viewport-dependent.test.js
@@ -210,7 +210,6 @@ ruleTester.run('no-viewport-dependent', rule, {
       code: 'target.scrollWidth',
       filename: 'TargetScroll.test.js'
     },
-
     // Non-window/screen destructuring (should be valid)
     {
       code: 'const { width, height } = element',

--- a/tests/lib/rules/no-viewport-dependent.test.js
+++ b/tests/lib/rules/no-viewport-dependent.test.js
@@ -76,7 +76,8 @@ ruleTester.run('no-viewport-dependent', rule, {
     },
     {
       code: 'matchMedia("(max-width: 600px)").matches',
-      filename: 'MatchMedia.test.js'
+      filename: 'MatchMedia.test.js',
+      options: [{ ignoreMediaQueries: true }]
     },
 
     // Reading but not depending on values
@@ -142,6 +143,14 @@ ruleTester.run('no-viewport-dependent', rule, {
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) { }
       `,
       filename: 'MatchMediaIgnore.test.js',
+      options: [{ ignoreMediaQueries: true }]
+    },
+    {
+      code: `
+        const isMobile = matchMedia('(max-width: 600px)').matches;
+        if (matchMedia('(prefers-color-scheme: dark)').matches) { }
+      `,
+      filename: 'GlobalMatchMediaIgnore.test.js',
       options: [{ ignoreMediaQueries: true }]
     },
 
@@ -567,6 +576,17 @@ ruleTester.run('no-viewport-dependent', rule, {
       errors: [{
         messageId: 'avoidViewportCheck',
         data: { property: 'window.matchMedia' }
+      }]
+    },
+
+    // Global matchMedia (without window prefix) should also be flagged
+    {
+      code: 'matchMedia(\'(max-width: 768px)\')',
+      filename: 'GlobalMediaQuery.test.js',
+      options: [{ ignoreMediaQueries: false }],
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'matchMedia' }
       }]
     },
 

--- a/tests/lib/rules/no-viewport-dependent.test.js
+++ b/tests/lib/rules/no-viewport-dependent.test.js
@@ -120,7 +120,7 @@ ruleTester.run('no-viewport-dependent', rule, {
         describe('Mobile viewport', () => {
           test('handles small screens', () => {
             const isMobile = window.innerWidth < 768;
-            screen.width > 375;
+            expect(screen.width).toBeGreaterThan(375);
           });
         });
       `,
@@ -210,7 +210,6 @@ ruleTester.run('no-viewport-dependent', rule, {
       code: 'target.scrollWidth',
       filename: 'TargetScroll.test.js'
     },
-
 
     // Non-window/screen destructuring (should be valid)
     {

--- a/tests/lib/rules/no-viewport-dependent.test.js
+++ b/tests/lib/rules/no-viewport-dependent.test.js
@@ -1,0 +1,709 @@
+/**
+ * @fileoverview Tests for no-viewport-dependent rule
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/no-viewport-dependent');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
+
+const ruleTester = getRuleTester();
+
+ruleTester.run('no-viewport-dependent', rule, {
+  valid: [
+    // Non-test files should be ignored
+    {
+      code: 'window.innerWidth',
+      filename: 'src/app.js'
+    },
+    {
+      code: 'if (window.innerHeight > 768) { }',
+      filename: 'src/responsive.js'
+    },
+
+    // Using fixed viewport sizes
+    {
+      code: 'cy.viewport(1280, 720)',
+      filename: 'Viewport.cy.js'
+    },
+    {
+      code: 'page.setViewportSize({ width: 1920, height: 1080 })',
+      filename: 'playwright.spec.js'
+    },
+    {
+      code: 'await browser.setWindowSize(1024, 768)',
+      filename: 'webdriver.test.js'
+    },
+
+    // Using mocked values
+    {
+      code: 'Object.defineProperty(window, "innerWidth", { value: 1024 })',
+      filename: 'MockWidth.test.js'
+    },
+    {
+      code: 'jest.spyOn(window, "innerHeight", "get").mockReturnValue(768)',
+      filename: 'MockHeight.test.js'
+    },
+
+    // Testing with specific breakpoints
+    {
+      code: 'const MOBILE_WIDTH = 375; cy.viewport(MOBILE_WIDTH, 667)',
+      filename: 'MobileTest.cy.js'
+    },
+    {
+      code: 'const DESKTOP_WIDTH = 1920; page.setViewportSize({ width: DESKTOP_WIDTH, height: 1080 })',
+      filename: 'DesktopTest.spec.js'
+    },
+
+    // Non-viewport properties
+    {
+      code: 'element.offsetWidth',
+      filename: 'ElementWidth.test.js'
+    },
+    {
+      code: 'container.clientHeight',
+      filename: 'ClientHeight.test.js'
+    },
+    {
+      code: 'div.scrollWidth',
+      filename: 'ScrollWidth.test.js'
+    },
+
+    // Using media query testing utilities
+    {
+      code: 'expect(element).toBeVisible({ media: "(min-width: 768px)" })',
+      filename: 'MediaQuery.test.js'
+    },
+    {
+      code: 'matchMedia("(max-width: 600px)").matches',
+      filename: 'MatchMedia.test.js'
+    },
+
+    // Reading but not depending on values
+    {
+      code: 'console.log("Current width:", window.innerWidth)',
+      filename: 'Logging.test.js'
+    },
+    {
+      code: 'const debug = { width: window.innerWidth, height: window.innerHeight }',
+      filename: 'Debug.test.js'
+    },
+
+    // Tests with allowViewportSetup: true and viewport is set
+    // Note: These still report errors because hasSetViewport is evaluated after the checks
+    // This is expected behavior - viewport should be set in beforeEach/setup hooks
+    {
+      code: `
+        page.setViewport({ width: 1024, height: 768 });
+        expect(window.innerHeight).toBeGreaterThan(600);
+      `,
+      filename: 'SetViewport.test.js',
+      options: [{ allowViewportSetup: true }]
+    },
+
+    // Tests with allowResponsiveTests: true
+    {
+      code: `
+        describe('Responsive design tests', () => {
+          it('adjusts to viewport', () => {
+            if (window.innerWidth < 768) {
+              expect(element).toHaveClass('mobile');
+            }
+          });
+        });
+      `,
+      filename: 'ResponsiveTests.test.js',
+      options: [{ allowResponsiveTests: true }]
+    },
+    {
+      code: `
+        describe('Mobile viewport', () => {
+          test('handles small screens', () => {
+            const isMobile = window.innerWidth < 768;
+            screen.width > 375;
+          });
+        });
+      `,
+      filename: 'MobileViewport.test.js',
+      options: [{ allowResponsiveTests: true }]
+    },
+    // These test names don't contain responsive keywords so they won't be detected as responsive tests
+
+    // Tests with ignoreMediaQueries: true
+    {
+      code: `
+        window.matchMedia('(max-width: 768px)');
+        window.matchMedia('(orientation: portrait)');
+      `,
+      filename: 'MediaQueries.test.js',
+      options: [{ ignoreMediaQueries: true }]
+    },
+    {
+      code: `
+        const isMobile = window.matchMedia('(max-width: 600px)').matches;
+        if (window.matchMedia('(prefers-color-scheme: dark)').matches) { }
+      `,
+      filename: 'MatchMediaIgnore.test.js',
+      options: [{ ignoreMediaQueries: true }]
+    },
+
+    // Combined options
+    {
+      code: `
+        describe('Responsive tests', () => {
+          it('handles media queries', () => {
+            window.matchMedia('(min-width: 768px)');
+            window.innerWidth > 768;
+          });
+        });
+      `,
+      filename: 'Combined.test.js',
+      options: [{ allowResponsiveTests: true, ignoreMediaQueries: true }]
+    },
+    {
+      code: `
+        cy.viewport(1920, 1080);
+        window.matchMedia('(min-width: 1200px)');
+        window.innerWidth;
+      `,
+      filename: 'AllOptions.cy.js',
+      options: [{ allowViewportSetup: true, ignoreMediaQueries: true }]
+    },
+
+    // Scroll properties that should be ignored for mocked/element objects
+    {
+      code: 'mockElement.scrollTop',
+      filename: 'MockScroll.test.js'
+    },
+    {
+      code: 'stubObject.scrollLeft',
+      filename: 'StubScroll.test.js'
+    },
+    {
+      code: 'spyElement.scrollHeight',
+      filename: 'SpyScroll.test.js'
+    },
+    {
+      code: 'div.scrollWidth',
+      filename: 'DivScroll.test.js'
+    },
+    {
+      code: 'element.scrollTop',
+      filename: 'ElementScroll.test.js'
+    },
+    {
+      code: 'container.scrollLeft',
+      filename: 'ContainerScroll.test.js'
+    },
+    {
+      code: 'node.scrollHeight',
+      filename: 'NodeScroll.test.js'
+    },
+    {
+      code: 'target.scrollWidth',
+      filename: 'TargetScroll.test.js'
+    },
+
+
+    // Non-window/screen destructuring (should be valid)
+    {
+      code: 'const { width, height } = element',
+      filename: 'ElementDestruct.test.js'
+    },
+    {
+      code: 'const { innerWidth, innerHeight } = config',
+      filename: 'ConfigDestruct.test.js'
+    },
+
+  ],
+
+  invalid: [
+    // Direct window dimension checks
+    {
+      code: 'if (window.innerWidth > 768) { }',
+      filename: 'WindowWidth.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+    {
+      code: 'if (window.innerHeight < 600) { }',
+      filename: 'WindowHeight.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerHeight' }
+      }]
+    },
+    {
+      code: 'expect(window.innerWidth).toBeGreaterThan(1024)',
+      filename: 'ExpectWidth.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+    {
+      code: 'expect(window.innerHeight).toBeLessThan(768)',
+      filename: 'ExpectHeight.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerHeight' }
+      }]
+    },
+
+    // window.outerWidth/outerHeight
+    {
+      code: 'if (window.outerWidth > 1280) { }',
+      filename: 'OuterWidth.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.outerWidth' }
+      }]
+    },
+    {
+      code: 'const height = window.outerHeight',
+      filename: 'OuterHeight.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.outerHeight' }
+      }]
+    },
+
+    // screen dimensions
+    {
+      code: 'if (screen.width > 1920) { }',
+      filename: 'ScreenWidth.test.js',
+      errors: [{
+        messageId: 'avoidScreenCheck',
+        data: { property: 'screen.width' }
+      }]
+    },
+    {
+      code: 'const screenHeight = screen.height',
+      filename: 'ScreenHeight.test.js',
+      errors: [{
+        messageId: 'avoidScreenCheck',
+        data: { property: 'screen.height' }
+      }]
+    },
+    {
+      code: 'screen.availWidth > 1024',
+      filename: 'AvailWidth.test.js',
+      errors: [{
+        messageId: 'avoidScreenCheck',
+        data: { property: 'screen.availWidth' }
+      }]
+    },
+    {
+      code: 'screen.availHeight < 768',
+      filename: 'AvailHeight.test.js',
+      errors: [{
+        messageId: 'avoidScreenCheck',
+        data: { property: 'screen.availHeight' }
+      }]
+    },
+
+    // visualViewport
+    {
+      code: 'if (visualViewport.width > 375) { }',
+      filename: 'VisualWidth.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'visualViewport.width' }
+      }]
+    },
+    {
+      code: 'visualViewport.height < 667',
+      filename: 'VisualHeight.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'visualViewport.height' }
+      }]
+    },
+
+    // document.documentElement dimensions
+    {
+      code: 'document.documentElement.clientWidth > 768',
+      filename: 'DocumentWidth.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'document.documentElement.clientWidth' }
+      }]
+    },
+    {
+      code: 'document.documentElement.clientHeight < 600',
+      filename: 'DocumentHeight.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'document.documentElement.clientHeight' }
+      }]
+    },
+
+    // document.body dimensions
+    {
+      code: 'document.body.clientWidth > 1024',
+      filename: 'BodyWidth.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'document.body.clientWidth' }
+      }]
+    },
+    {
+      code: 'document.body.clientHeight < 768',
+      filename: 'BodyHeight.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'document.body.clientHeight' }
+      }]
+    },
+
+    // getBoundingClientRect on viewport elements
+    {
+      code: 'document.documentElement.getBoundingClientRect().width',
+      filename: 'BoundingWidth.test.js',
+      errors: [{
+        messageId: 'avoidBoundingRect'
+      }]
+    },
+    {
+      code: 'document.body.getBoundingClientRect().height',
+      filename: 'BoundingHeight.test.js',
+      errors: [{
+        messageId: 'avoidBoundingRect'
+      }]
+    },
+
+    // Responsive breakpoint testing
+    {
+      code: 'const isMobile = window.innerWidth < 768',
+      filename: 'MobileCheck.test.js',
+      errors: [{
+        messageId: 'useFixedViewport'
+      }]
+    },
+    {
+      code: 'const isDesktop = window.innerWidth >= 1024',
+      filename: 'DesktopCheck.test.js',
+      errors: [{
+        messageId: 'useFixedViewport'
+      }]
+    },
+    {
+      code: 'if (window.innerWidth < 600) { expect(menu).not.toBeVisible() }',
+      filename: 'ResponsiveMenu.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+
+    // Variable assignments
+    {
+      code: 'const width = window.innerWidth; if (width > 768) { }',
+      filename: 'VariableWidth.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+    {
+      code: 'const { innerHeight: height } = window; expect(height).toBeGreaterThan(600)',
+      filename: 'DestructuredHeight.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerHeight' }
+      }]
+    },
+
+    // Multiple violations
+    {
+      code: `
+        if (window.innerWidth > 768 && window.innerHeight > 600) {
+          expect(element).toBeVisible();
+        }
+        const screenSize = screen.width;
+      `,
+      filename: 'Multiple.test.js',
+      errors: [
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerWidth' } },
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerHeight' } },
+        { messageId: 'avoidScreenCheck', data: { property: 'screen.width' } }
+      ]
+    },
+
+    // In test blocks
+    {
+      code: 'it("responds to viewport", () => { if (window.innerWidth > 768) { } })',
+      filename: 'TestBlock.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+    {
+      code: 'test("screen size", () => { expect(screen.width).toBeGreaterThan(1024) })',
+      filename: 'TestCase.test.js',
+      errors: [{
+        messageId: 'avoidScreenCheck',
+        data: { property: 'screen.width' }
+      }]
+    },
+
+    // Different test file extensions
+    {
+      code: 'window.innerWidth > 768',
+      filename: 'Viewport.spec.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+    {
+      code: 'screen.height < 600',
+      filename: 'test/screen.test.ts',
+      errors: [{
+        messageId: 'avoidScreenCheck',
+        data: { property: 'screen.height' }
+      }]
+    },
+    {
+      code: 'document.documentElement.clientWidth',
+      filename: '__tests__/document.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'document.documentElement.clientWidth' }
+      }]
+    },
+
+    // Complex expressions
+    {
+      code: 'const aspectRatio = window.innerWidth / window.innerHeight',
+      filename: 'AspectRatio.test.js',
+      errors: [
+        { messageId: 'useFixedViewport' },
+        { messageId: 'useFixedViewport' }
+      ]
+    },
+    {
+      code: 'Math.min(window.innerWidth, window.innerHeight)',
+      filename: 'MinDimension.test.js',
+      errors: [
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerWidth' } },
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerHeight' } }
+      ]
+    },
+
+    // Resize event handlers
+    {
+      code: 'window.addEventListener("resize", () => { if (window.innerWidth > 768) { } })',
+      filename: 'ResizeEvent.test.js',
+      errors: [
+        { messageId: 'avoidResizeListener' },
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerWidth' } }
+      ]
+    },
+    {
+      code: 'window.onresize = () => { updateLayout(window.innerWidth) }',
+      filename: 'OnResize.test.js',
+      errors: [{
+        messageId: 'avoidResizeListener'
+      }]
+    },
+
+    // Orientation checks
+    {
+      code: 'if (window.innerWidth > window.innerHeight) { }',
+      filename: 'Orientation.test.js',
+      errors: [
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerWidth' } },
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerHeight' } }
+      ]
+    },
+    {
+      code: 'const isLandscape = screen.width > screen.height',
+      filename: 'Landscape.test.js',
+      errors: [
+        { messageId: 'useFixedViewport' },
+        { messageId: 'useFixedViewport' }
+      ]
+    },
+
+    // Tests with options that should still fail
+    // allowViewportSetup: false should flag even with viewport setup
+    {
+      code: `
+        cy.viewport(1280, 720);
+        if (window.innerWidth > 768) { }
+      `,
+      filename: 'NoAllowSetup.cy.js',
+      options: [{ allowViewportSetup: false }],
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+
+    // allowResponsiveTests: false (default) should flag responsive tests
+    {
+      code: `
+        describe('Regular test', () => {
+          it('should fail on viewport check', () => {
+            if (window.innerWidth < 768) { }
+          });
+        });
+      `,
+      filename: 'NotResponsive.test.js',
+      options: [{ allowResponsiveTests: false }],
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+
+    // ignoreMediaQueries: false (default) should flag media queries
+    {
+      code: 'window.matchMedia(\'(max-width: 768px)\')',
+      filename: 'MediaQueryNotIgnored.test.js',
+      options: [{ ignoreMediaQueries: false }],
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.matchMedia' }
+      }]
+    },
+
+    // Test with responsive in name but allowResponsiveTests: false
+    {
+      code: `
+        describe('Non-responsive test', () => {
+          it('checks viewport', () => {
+            window.innerWidth > 768;
+          });
+        });
+      `,
+      filename: 'FalseResponsive.test.js',
+      options: [{ allowResponsiveTests: false }],
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'window.innerWidth' }
+      }]
+    },
+
+    // Multiple options but still violating
+    {
+      code: `
+        window.innerWidth > 768;
+        window.matchMedia('(min-width: 1024px)');
+      `,
+      filename: 'MultiOptions.test.js',
+      options: [{ allowViewportSetup: false, ignoreMediaQueries: false }],
+      errors: [
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerWidth' } },
+        { messageId: 'avoidViewportCheck', data: { property: 'window.matchMedia' } }
+      ]
+    },
+
+    // ResizeObserver tests
+    {
+      code: 'new ResizeObserver(() => {})',
+      filename: 'ResizeObserver.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'ResizeObserver' }
+      }]
+    },
+
+    // IntersectionObserver tests
+    {
+      code: 'new IntersectionObserver(() => {})',
+      filename: 'IntersectionObserver.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'viewport-IntersectionObserver' }
+      }]
+    },
+
+    // Scroll properties
+    {
+      code: 'window.scrollY > 100',
+      filename: 'ScrollY.test.js',
+      errors: [{
+        messageId: 'avoidScrollCheck'
+      }]
+    },
+    {
+      code: 'window.pageYOffset < 200',
+      filename: 'PageYOffset.test.js',
+      errors: [{
+        messageId: 'avoidScrollCheck'
+      }]
+    },
+    {
+      code: 'someElement.scrollTop',
+      filename: 'ScrollTop.test.js',
+      errors: [{
+        messageId: 'avoidScrollCheck'
+      }]
+    },
+
+    // document.body offset dimensions
+    {
+      code: 'document.body.offsetWidth',
+      filename: 'BodyOffsetWidth.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'document.body.offsetWidth' }
+      }]
+    },
+    {
+      code: 'document.body.offsetHeight > 600',
+      filename: 'BodyOffsetHeight.test.js',
+      errors: [{
+        messageId: 'avoidViewportCheck',
+        data: { property: 'document.body.offsetHeight' }
+      }]
+    },
+
+    // Destructuring from window
+    {
+      code: 'const { innerWidth, outerWidth } = window',
+      filename: 'Destructuring.test.js',
+      errors: [
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerWidth' } },
+        { messageId: 'avoidViewportCheck', data: { property: 'window.outerWidth' } }
+      ]
+    },
+    {
+      code: 'const { width, height } = screen',
+      filename: 'DestructureScreen.test.js',
+      errors: [
+        { messageId: 'avoidScreenCheck', data: { property: 'screen.width' } },
+        { messageId: 'avoidScreenCheck', data: { property: 'screen.height' } }
+      ]
+    },
+    {
+      code: 'const { availWidth, availHeight } = screen',
+      filename: 'DestructureAvail.test.js',
+      errors: [
+        { messageId: 'avoidScreenCheck', data: { property: 'screen.availWidth' } },
+        { messageId: 'avoidScreenCheck', data: { property: 'screen.availHeight' } }
+      ]
+    },
+
+    // Test function declaration break in binary expression
+    {
+      code: `
+        function test() {
+          if (window.innerWidth > screen.width) {
+            return true;
+          }
+        }
+      `,
+      filename: 'FunctionDeclaration.test.js',
+      errors: [
+        { messageId: 'avoidViewportCheck', data: { property: 'window.innerWidth' } },
+        { messageId: 'avoidScreenCheck', data: { property: 'screen.width' } }
+      ]
+    }
+  ]
+});

--- a/tests/lib/rules/no-viewport-dependent.test.js
+++ b/tests/lib/rules/no-viewport-dependent.test.js
@@ -90,7 +90,7 @@ ruleTester.run('no-viewport-dependent', rule, {
       filename: 'Debug.test.js'
     },
 
-    // Tests with allowViewportSetup: true and explicit viewport setting are considered valid.
+    // Note: Tests with allowViewportSetup: true and explicit viewport setting are considered valid.
     // This is expected behavior when the viewport is set in the test body.
     {
       code: `


### PR DESCRIPTION
## Existing Behavior
- Tests could freely access viewport properties like `window.innerWidth`, `screen.width`, and element positioning methods without warnings
- No detection of viewport-dependent assertions that could fail across different screen resolutions, browser environments, or device types
- Tests using media queries, scroll positions, and element bounding rectangles went unchecked for viewport dependencies
- No guidance or enforcement for consistent viewport setup in test suites

## Intended New Behavior
- New ESLint rule detects viewport-dependent properties including window dimensions, screen properties, element positioning, and scroll positions
- Comprehensive pattern matching identifies media query usage, CSS computed styles, and viewport-relative measurements that could cause test flakiness
- Configurable options allow viewport setup in hooks, responsive design testing, and media query testing based on project needs
- Rule provides detailed documentation with best practices for viewport-independent testing and proper responsive test setup

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo
1. Install the ESLint plugin and configure the `no-viewport-dependent` rule in your ESLint config
2. Run ESLint on test files containing viewport-dependent assertions:
   - Test files with `window.innerWidth` checks should trigger violations
   - Test files with `getBoundingClientRect()` calls should be flagged
   - Files using `window.matchMedia()` should show warnings (unless `ignoreMediaQueries: true`)
3. Verify rule options work correctly:
   - Set `allowViewportSetup: true` and confirm viewport setup in `beforeEach` hooks is allowed
   - Enable `allowResponsiveTests: true` for responsive design test suites
   - Toggle `ignoreMediaQueries: true` to allow media query testing
4. Test the example violations file (`examples/no-viewport-dependent-violations.test.js`) should trigger multiple rule violations when linted
5. Verify the comprehensive documentation at `docs/rules/no-viewport-dependent.md` provides clear examples of violations and correct patterns