### PR TITLE
refactor(test): consolidate RuleTester configuration using getRuleTester helper

### DIFF
--- a/tests/lib/rules/await-async-events.test.js
+++ b/tests/lib/rules/await-async-events.test.js
@@ -5,31 +5,9 @@
 'use strict';
 
 const rule = require('../../../lib/rules/await-async-events');
-const { RuleTester } = require('eslint');
-const semver = require('semver');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
 
-// Detect ESLint version for proper RuleTester configuration
-const eslintPackage = require('eslint/package.json');
-const eslintVersion = semver.major(eslintPackage.version);
-
-// Configure RuleTester based on ESLint version
-const ruleTesterConfig = eslintVersion >= 9
-  ? {
-      // ESLint 9+ (flat config)
-      languageOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    }
-  : {
-      // ESLint 7-8 (legacy config)
-      parserOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    };
-
-const ruleTester = new RuleTester(ruleTesterConfig);
+const ruleTester = getRuleTester();
 
 ruleTester.run('await-async-events', rule, {
   valid: [

--- a/tests/lib/rules/no-animation-wait.test.js
+++ b/tests/lib/rules/no-animation-wait.test.js
@@ -5,31 +5,9 @@
 'use strict';
 
 const rule = require('../../../lib/rules/no-animation-wait');
-const { RuleTester } = require('eslint');
-const semver = require('semver');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
 
-// Detect ESLint version for proper RuleTester configuration
-const eslintPackage = require('eslint/package.json');
-const eslintVersion = semver.major(eslintPackage.version);
-
-// Configure RuleTester based on ESLint version
-const ruleTesterConfig = eslintVersion >= 9
-  ? {
-      // ESLint 9+ (flat config)
-      languageOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    }
-  : {
-      // ESLint 7-8 (legacy config)
-      parserOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    };
-
-const ruleTester = new RuleTester(ruleTesterConfig);
+const ruleTester = getRuleTester();
 
 ruleTester.run('no-animation-wait', rule, {
   valid: [

--- a/tests/lib/rules/no-database-operations.test.js
+++ b/tests/lib/rules/no-database-operations.test.js
@@ -5,31 +5,9 @@
 'use strict';
 
 const rule = require('../../../lib/rules/no-database-operations');
-const { RuleTester } = require('eslint');
-const semver = require('semver');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
 
-// Detect ESLint version for proper RuleTester configuration
-const eslintPackage = require('eslint/package.json');
-const eslintVersion = semver.major(eslintPackage.version);
-
-// Configure RuleTester based on ESLint version
-const ruleTesterConfig = eslintVersion >= 9
-  ? {
-      // ESLint 9+ (flat config)
-      languageOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    }
-  : {
-      // ESLint 7-8 (legacy config)
-      parserOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    };
-
-const ruleTester = new RuleTester(ruleTesterConfig);
+const ruleTester = getRuleTester();
 
 ruleTester.run('no-database-operations', rule, {
   valid: [

--- a/tests/lib/rules/no-element-removal-check.test.js
+++ b/tests/lib/rules/no-element-removal-check.test.js
@@ -5,31 +5,9 @@
 'use strict';
 
 const rule = require('../../../lib/rules/no-element-removal-check');
-const { RuleTester } = require('eslint');
-const semver = require('semver');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
 
-// Detect ESLint version for proper RuleTester configuration
-const eslintPackage = require('eslint/package.json');
-const eslintVersion = semver.major(eslintPackage.version);
-
-// Configure RuleTester based on ESLint version
-const ruleTesterConfig = eslintVersion >= 9
-  ? {
-      // ESLint 9+ (flat config)
-      languageOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    }
-  : {
-      // ESLint 7-8 (legacy config)
-      parserOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    };
-
-const ruleTester = new RuleTester(ruleTesterConfig);
+const ruleTester = getRuleTester();
 
 ruleTester.run('no-element-removal-check', rule, {
   valid: [

--- a/tests/lib/rules/no-hard-coded-timeout.test.js
+++ b/tests/lib/rules/no-hard-coded-timeout.test.js
@@ -5,30 +5,9 @@
 'use strict';
 
 const rule = require('../../../lib/rules/no-hard-coded-timeout');
-const { RuleTester } = require('eslint');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
 
-// Detect ESLint version for proper RuleTester configuration
-const eslintPackage = require('eslint/package.json');
-const eslintVersion = parseInt(eslintPackage.version.split('.')[0], 10);
-
-// Configure RuleTester based on ESLint version
-const ruleTesterConfig = eslintVersion >= 9
-  ? {
-      // ESLint 9+ (flat config)
-      languageOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    }
-  : {
-      // ESLint 7-8 (legacy config)
-      parserOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module'
-      }
-    };
-
-const ruleTester = new RuleTester(ruleTesterConfig);
+const ruleTester = getRuleTester();
 
 ruleTester.run('no-hard-coded-timeout', rule, {
   valid: [


### PR DESCRIPTION
## Summary
This PR refactors ESLint rule test files to use a centralized `getRuleTester()` helper function, eliminating ~125 lines of duplicated configuration code across 5 test files.

## Changes
- Replaced duplicated RuleTester setup in 5 test files with centralized helper
- Removed redundant ESLint version detection and semver imports
- Simplified test file structure by importing `getRuleTester()` from test-helpers utility

## Affected Files
- `tests/lib/rules/await-async-events.test.js`
- `tests/lib/rules/no-animation-wait.test.js`  
- `tests/lib/rules/no-database-operations.test.js`
- `tests/lib/rules/no-element-removal-check.test.js`
- `tests/lib/rules/no-hard-coded-timeout.test.js`

## Benefits
- Eliminates code duplication across test files
- Centralizes ESLint version compatibility logic
- Improves maintainability of test suite
- Ensures consistent RuleTester configuration

## Testing
All existing tests continue to pass with identical behavior. The refactoring only changes how the RuleTester is configured, not the test logic itself.