### PR TITLE
Add global installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,45 @@ pnpm add -D eslint-plugin-test-flakiness
 
 - See the plugin in action with interactive examples
 
+### Global Installation (No Project Changes)
+
+For projects where you can't add dev dependencies (e.g., org-controlled repos), install globally and run without touching the project:
+
+```bash
+# Install globally (--ignore-scripts bypasses preinstall hooks like "only-allow pnpm")
+npm install -g --ignore-scripts eslint@8 @typescript-eslint/parser@7 eslint-plugin-test-flakiness
+```
+
+**Run with all rules:**
+
+```bash
+NODE_PATH=$(npm root -g) eslint --no-eslintrc \
+  --parser @typescript-eslint/parser \
+  --plugin test-flakiness \
+  --rule '{"test-flakiness/await-async-events":"warn","test-flakiness/no-animation-wait":"warn","test-flakiness/no-database-operations":"warn","test-flakiness/no-element-removal-check":"warn","test-flakiness/no-focus-check":"warn","test-flakiness/no-global-state-mutation":"warn","test-flakiness/no-hard-coded-timeout":"warn","test-flakiness/no-immediate-assertions":"warn","test-flakiness/no-index-queries":"warn","test-flakiness/no-long-text-match":"warn","test-flakiness/no-promise-race":"warn","test-flakiness/no-random-data":"warn","test-flakiness/no-test-focus":"warn","test-flakiness/no-test-isolation":"warn","test-flakiness/no-unconditional-wait":"warn","test-flakiness/no-unmocked-fs":"warn","test-flakiness/no-unmocked-network":"warn","test-flakiness/no-viewport-dependent":"warn"}' \
+  'tests/**/*.spec.ts'
+```
+
+**Run on a single file:**
+
+```bash
+NODE_PATH=$(npm root -g) eslint --no-eslintrc \
+  --parser @typescript-eslint/parser \
+  --plugin test-flakiness \
+  --rule '{"test-flakiness/no-hard-coded-timeout":"warn","test-flakiness/no-element-removal-check":"warn","test-flakiness/no-index-queries":"warn"}' \
+  'path/to/my-test.spec.ts'
+```
+
+**Optional shell alias** (add to `~/.bashrc` or `~/.zshrc`):
+
+```bash
+alias lint-flaky='NODE_PATH=$(npm root -g) eslint --no-eslintrc --parser @typescript-eslint/parser --plugin test-flakiness --rule '"'"'{"test-flakiness/await-async-events":"warn","test-flakiness/no-animation-wait":"warn","test-flakiness/no-database-operations":"warn","test-flakiness/no-element-removal-check":"warn","test-flakiness/no-focus-check":"warn","test-flakiness/no-global-state-mutation":"warn","test-flakiness/no-hard-coded-timeout":"warn","test-flakiness/no-immediate-assertions":"warn","test-flakiness/no-index-queries":"warn","test-flakiness/no-long-text-match":"warn","test-flakiness/no-promise-race":"warn","test-flakiness/no-random-data":"warn","test-flakiness/no-test-focus":"warn","test-flakiness/no-test-isolation":"warn","test-flakiness/no-unconditional-wait":"warn","test-flakiness/no-unmocked-fs":"warn","test-flakiness/no-unmocked-network":"warn","test-flakiness/no-viewport-dependent":"warn"}'"'"
+```
+
+Then: `lint-flaky 'tests/**/*.spec.ts'`
+
+> **How it works:** `NODE_PATH` tells Node.js where to find globally installed modules. `--no-eslintrc` prevents ESLint from reading the project's config. No files in the project are modified.
+
 ### Flat Config (ESLint 9+)
 
 ```javascript


### PR DESCRIPTION
Add global installation instructions to README

# Description

Add a "Global Installation (No Project Changes)" section to the README, enabling users to run the plugin without modifying any project files. This is useful for org-controlled repos where adding dev dependencies is restricted.

The section includes:
- Global install command with `--ignore-scripts` flag (bypasses `only-allow pnpm` preinstall hooks)
- Full run command with all 18 rules using `NODE_PATH` to resolve global modules
- Single-file run command for targeted analysis
- Optional shell alias (`lint-flaky`) for convenience
- Explanation of how `NODE_PATH` and `--no-eslintrc` work together

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issue

N/A — Feature request based on real-world usage in a pnpm-only monorepo where adding dev dependencies requires org approval.

## Changes Made

- Added "Global Installation (No Project Changes)" section to README.md, positioned after Quick Start and before Flat Config
- Includes install command: `npm install -g --ignore-scripts eslint@8 @typescript-eslint/parser@7 eslint-plugin-test-flakiness`
- Includes run commands with `NODE_PATH=$(npm root -g)` for global module resolution
- Includes optional shell alias for repeated usage
- Documents the `--ignore-scripts` requirement for projects with package manager enforcement hooks

## Testing

- [x] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Tested with ESLint 7.x
- [x] Tested with ESLint 8.x
- [ ] Tested with ESLint 9.x
- [x] Tested with relevant test frameworks (Jest/Vitest/Playwright/Cypress)

**Manual testing performed:**
- Installed globally on Node.js 24.x with nvm
- Ran against a Playwright E2E test suite (37 spec files) in a pnpm monorepo with `only-allow pnpm` preinstall hook
- Successfully detected 19 flakiness warnings across 3 known flaky test files
- Verified `NODE_PATH` approach works from any directory/worktree without project modifications

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A — Documentation-only change.

## Additional Notes

- The `--ignore-scripts` flag is critical for the global install to work in environments where `npm install -g` triggers project-level preinstall hooks (e.g., `only-allow pnpm`). Without it, the install fails with `ENOENT` errors.
- Tested on Node.js 24.x with ESLint 8.57.1 and @typescript-eslint/parser 7.x.
- The `NODE_PATH` approach is a standard Node.js mechanism — no hacks or workarounds involved.
