### PR TITLE
feat: add lint-flaky CLI bin script for global npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,40 +56,31 @@ pnpm add -D eslint-plugin-test-flakiness
 For projects where dev dependencies cannot be added, install globally:
 
 ```bash
-# Install globally (--ignore-scripts bypasses preinstall hooks like "only-allow pnpm")
-npm install -g --ignore-scripts eslint@8 @typescript-eslint/parser@7 eslint-plugin-test-flakiness
+npm install -g --ignore-scripts eslint @typescript-eslint/parser eslint-plugin-test-flakiness
 ```
 
-**Run with all rules:**
+**Run with the `lint-flaky` CLI:**
 
 ```bash
-NODE_PATH=$(npm root -g) eslint --no-eslintrc \
-  --parser @typescript-eslint/parser \
-  --plugin test-flakiness \
-  --rule '{"test-flakiness/await-async-events":"warn","test-flakiness/no-animation-wait":"warn","test-flakiness/no-database-operations":"warn","test-flakiness/no-element-removal-check":"warn","test-flakiness/no-focus-check":"warn","test-flakiness/no-global-state-mutation":"warn","test-flakiness/no-hard-coded-timeout":"warn","test-flakiness/no-immediate-assertions":"warn","test-flakiness/no-index-queries":"warn","test-flakiness/no-long-text-match":"warn","test-flakiness/no-promise-race":"warn","test-flakiness/no-random-data":"warn","test-flakiness/no-test-focus":"warn","test-flakiness/no-test-isolation":"warn","test-flakiness/no-unconditional-wait":"warn","test-flakiness/no-unmocked-fs":"warn","test-flakiness/no-unmocked-network":"warn","test-flakiness/no-viewport-dependent":"warn"}' \
-  'tests/**/*.spec.ts'
+# Lint all test files with all rules (default severity: warn)
+lint-flaky 'tests/**/*.spec.ts'
+
+# Treat violations as errors (non-zero exit code)
+lint-flaky --severity error 'app/e2e/specs/**/*.spec.ts'
+
+# Auto-fix where possible
+lint-flaky --fix 'tests/**/*.test.ts'
+
+# Use a specific ESLint formatter
+lint-flaky --format json 'tests/**/*.spec.ts'
+
+# Show all available rules and options
+lint-flaky --help
 ```
 
-**Run on a single file:**
-
-```bash
-NODE_PATH=$(npm root -g) eslint --no-eslintrc \
-  --parser @typescript-eslint/parser \
-  --plugin test-flakiness \
-  --rule '{"test-flakiness/no-hard-coded-timeout":"warn","test-flakiness/no-element-removal-check":"warn","test-flakiness/no-index-queries":"warn"}' \
-  'path/to/my-test.spec.ts'
-```
-
-**Optional shell alias** (add to `~/.bashrc` or `~/.zshrc`):
-
-```bash
-alias lint-flaky='NODE_PATH=$(npm root -g) eslint --no-eslintrc --parser @typescript-eslint/parser --plugin test-flakiness --rule '"'"'{"test-flakiness/await-async-events":"warn","test-flakiness/no-animation-wait":"warn","test-flakiness/no-database-operations":"warn","test-flakiness/no-element-removal-check":"warn","test-flakiness/no-focus-check":"warn","test-flakiness/no-global-state-mutation":"warn","test-flakiness/no-hard-coded-timeout":"warn","test-flakiness/no-immediate-assertions":"warn","test-flakiness/no-index-queries":"warn","test-flakiness/no-long-text-match":"warn","test-flakiness/no-promise-race":"warn","test-flakiness/no-random-data":"warn","test-flakiness/no-test-focus":"warn","test-flakiness/no-test-isolation":"warn","test-flakiness/no-unconditional-wait":"warn","test-flakiness/no-unmocked-fs":"warn","test-flakiness/no-unmocked-network":"warn","test-flakiness/no-viewport-dependent":"warn"}'"'"
-```
-
-Then: `lint-flaky 'tests/**/*.spec.ts'`
-
-> **How it works:** `NODE_PATH` tells Node.js where to find globally installed modules. `--no-eslintrc` prevents
-> ESLint from reading the project's config and skips project modification.
+> **How it works:** The `lint-flaky` command is installed automatically during `npm install -g`.
+> It runs ESLint with all flaky-test rules enabled, using the Node API for ESLint 9+ and the legacy CLI for ESLint 7/8.
+> No project configuration changes are needed.
 
 ### Flat Config (ESLint 9+)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ lint-flaky --help
 ```
 
 > **How it works:** The `lint-flaky` command is installed automatically during `npm install -g`.
-> It runs ESLint with all flaky-test rules enabled, using the Node API for ESLint 9+ and the legacy CLI for ESLint 7/8.
+> It runs ESLint 9+ with all flaky-test rules enabled via the Node API.
 > No project configuration changes are needed.
 
 ### Flat Config (ESLint 9+)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pnpm add -D eslint-plugin-test-flakiness
 
 ### Global Installation (No Project Changes)
 
-For projects where you can't add dev dependencies (e.g., org-controlled repos), install globally and run without touching the project:
+For projects where dev dependencies cannot be added, install globally:
 
 ```bash
 # Install globally (--ignore-scripts bypasses preinstall hooks like "only-allow pnpm")
@@ -88,7 +88,8 @@ alias lint-flaky='NODE_PATH=$(npm root -g) eslint --no-eslintrc --parser @typesc
 
 Then: `lint-flaky 'tests/**/*.spec.ts'`
 
-> **How it works:** `NODE_PATH` tells Node.js where to find globally installed modules. `--no-eslintrc` prevents ESLint from reading the project's config. No files in the project are modified.
+> **How it works:** `NODE_PATH` tells Node.js where to find globally installed modules. `--no-eslintrc` prevents
+> ESLint from reading the project's config and skips project modification.
 
 ### Flat Config (ESLint 9+)
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pnpm add -D eslint-plugin-test-flakiness
 
 ### Global Installation (No Project Changes)
 
-For projects where dev dependencies cannot be added, install globally:
+For projects where adding dev dependencies is not possible, install globally:
 
 ```bash
 npm install -g --ignore-scripts eslint @typescript-eslint/parser eslint-plugin-test-flakiness

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pnpm add -D eslint-plugin-test-flakiness
 For projects where adding dev dependencies is not possible, install globally:
 
 ```bash
-npm install -g --ignore-scripts eslint @typescript-eslint/parser eslint-plugin-test-flakiness
+npm install -g --ignore-scripts eslint@9 @typescript-eslint/parser eslint-plugin-test-flakiness
 ```
 
 **Run with the `lint-flaky` CLI:**

--- a/bin/lint-flaky.js
+++ b/bin/lint-flaky.js
@@ -79,16 +79,6 @@ const ruleConfig = rules.reduce((acc, rule) => {
   return acc;
 }, {});
 
-// Detect ESLint version to use the right approach
-let eslintMajor;
-try {
-  const eslintPkg = require('eslint/package.json');
-  eslintMajor = parseInt(eslintPkg.version.split('.')[0], 10);
-} catch (_e) {
-  console.error('Error: ESLint not found. Install it with: npm i -g eslint');
-  process.exit(1);
-}
-
 // Resolve cwd to the common parent of all file patterns so ESLint
 // doesn't reject files as "outside of base path"
 function resolveCommonDir(patterns) {
@@ -102,27 +92,9 @@ function resolveCommonDir(patterns) {
   }, path.dirname(resolved[0]));
 }
 
-async function formatAndExit(eslint, results) {
-  if (fix) {
-    const ESLintClass = eslint.constructor;
-    await ESLintClass.outputFixes(results);
-  }
-
-  const formatter = await eslint.loadFormatter(format);
-  const output = formatter.format
-    ? formatter.format(results)
-    : await formatter.format(results);
-  if (output) {
-    console.log(output);
-  }
-
-  const hasErrors = results.some(r => r.errorCount > 0);
-  if (hasErrors) process.exit(1);
-}
-
-async function runWithNodeAPI() {
-  const plugin = require(path.join(__dirname, '..', 'lib', 'index.js'));
+async function run() {
   const { ESLint } = require('eslint');
+  const plugin = require(path.join(__dirname, '..', 'lib', 'index.js'));
 
   let parser;
   try {
@@ -131,51 +103,39 @@ async function runWithNodeAPI() {
     parser = undefined;
   }
 
-  const commonDir = resolveCommonDir(filePatterns);
-  let eslint;
+  const overrideConfig = {
+    plugins: { 'test-flakiness': plugin },
+    rules: ruleConfig,
+  };
 
-  if (eslintMajor >= 9) {
-    // ESLint v9+ flat config via Node API
-    const overrideConfig = {
-      plugins: { 'test-flakiness': plugin },
-      rules: ruleConfig,
-    };
-
-    if (parser) {
-      overrideConfig.languageOptions = { parser };
-    }
-
-    eslint = new ESLint({
-      overrideConfigFile: true,
-      overrideConfig,
-      fix,
-      cwd: commonDir,
-    });
-  } else {
-    // ESLint v7/v8 Node API
-    const overrideConfig = {
-      plugins: ['test-flakiness'],
-      rules: ruleConfig,
-    };
-
-    if (parser) {
-      overrideConfig.parser = require.resolve('@typescript-eslint/parser');
-    }
-
-    eslint = new ESLint({
-      useEslintrc: false,
-      overrideConfig,
-      fix,
-      cwd: commonDir,
-      plugins: { 'test-flakiness': plugin },
-    });
+  if (parser) {
+    overrideConfig.languageOptions = { parser };
   }
 
+  const eslint = new ESLint({
+    overrideConfigFile: true,
+    overrideConfig,
+    fix,
+    cwd: resolveCommonDir(filePatterns),
+  });
+
   const results = await eslint.lintFiles(filePatterns);
-  await formatAndExit(eslint, results);
+
+  if (fix) {
+    await ESLint.outputFixes(results);
+  }
+
+  const formatter = await eslint.loadFormatter(format);
+  const output = formatter.format(results);
+  if (output) {
+    console.log(output);
+  }
+
+  const hasErrors = results.some(r => r.errorCount > 0);
+  if (hasErrors) process.exit(1);
 }
 
-runWithNodeAPI().catch((err) => {
+run().catch((err) => {
   console.error('Error:', err.message);
   process.exit(1);
 });

--- a/bin/lint-flaky.js
+++ b/bin/lint-flaky.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// Dynamically discover all rules from the plugin
+const rulesDir = path.join(__dirname, '..', 'lib', 'rules');
+let rules = [];
+if (fs.existsSync(rulesDir)) {
+  rules = fs.readdirSync(rulesDir)
+    .filter(f => f.endsWith('.js'))
+    .map(f => f.replace(/\.js$/, ''));
+}
+
+if (rules.length === 0) {
+  console.error('Error: No rules found in eslint-plugin-test-flakiness');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+
+if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+  console.log('Usage: lint-flaky [options] <glob-pattern>');
+  console.log('');
+  console.log('Lint test files for flaky test patterns.');
+  console.log('');
+  console.log('Examples:');
+  console.log('  lint-flaky "app/e2e/specs/**/*.spec.ts"');
+  console.log('  lint-flaky --fix "tests/**/*.test.ts"');
+  console.log('  lint-flaky --severity error "**/*.spec.ts"');
+  console.log('');
+  console.log('Options:');
+  console.log('  --fix              Automatically fix problems');
+  console.log('  --severity <level> Set rule severity: warn (default) or error');
+  console.log('  --format <name>    Use a specific ESLint formatter');
+  console.log('  -h, --help         Show this help message');
+  console.log('');
+  console.log(`Available rules (${rules.length}):`);
+  rules.sort().forEach(r => console.log(`  test-flakiness/${r}`));
+  process.exit(args.length === 0 ? 1 : 0);
+}
+
+// Parse custom options
+let severity = 'warn';
+let format = null;
+const eslintArgs = [];
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--severity' && args[i + 1]) {
+    severity = args[i + 1];
+    i++;
+  } else if (args[i] === '--format' && args[i + 1]) {
+    format = args[i + 1];
+    i++;
+  } else {
+    eslintArgs.push(args[i]);
+  }
+}
+
+const ruleConfig = rules.reduce((acc, rule) => {
+  acc[`test-flakiness/${rule}`] = severity;
+  return acc;
+}, {});
+
+const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
+
+const cmd = [
+  'eslint',
+  '--no-eslintrc',
+  '--parser', '@typescript-eslint/parser',
+  '--plugin', 'test-flakiness',
+  '--rule', JSON.stringify(ruleConfig),
+];
+
+if (format) {
+  cmd.push('--format', format);
+}
+
+cmd.push(...eslintArgs);
+
+try {
+  execSync(cmd.join(' '), {
+    stdio: 'inherit',
+    env: { ...process.env, NODE_PATH: globalRoot },
+  });
+} catch (e) {
+  process.exit(e.status || 1);
+}

--- a/bin/lint-flaky.js
+++ b/bin/lint-flaky.js
@@ -2,9 +2,9 @@
 
 'use strict';
 
-const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const { execFileSync } = require('child_process');
 
 // Dynamically discover all rules from the plugin
 const rulesDir = path.join(__dirname, '..', 'lib', 'rules');
@@ -45,19 +45,34 @@ if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
 
 // Parse custom options
 let severity = 'warn';
-let format = null;
-const eslintArgs = [];
+let format = 'stylish';
+let fix = false;
+const filePatterns = [];
+
+const validSeverities = ['warn', 'error', 'off'];
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--severity' && args[i + 1]) {
     severity = args[i + 1];
+    if (!validSeverities.includes(severity)) {
+      console.error(`Error: Invalid severity "${severity}". Must be one of: ${validSeverities.join(', ')}`);
+      process.exit(1);
+    }
     i++;
   } else if (args[i] === '--format' && args[i + 1]) {
     format = args[i + 1];
     i++;
+  } else if (args[i] === '--fix') {
+    fix = true;
   } else {
-    eslintArgs.push(args[i]);
+    filePatterns.push(args[i]);
   }
+}
+
+if (filePatterns.length === 0) {
+  console.error('Error: No file patterns specified');
+  console.error('Usage: lint-flaky <glob-pattern>');
+  process.exit(1);
 }
 
 const ruleConfig = rules.reduce((acc, rule) => {
@@ -65,27 +80,101 @@ const ruleConfig = rules.reduce((acc, rule) => {
   return acc;
 }, {});
 
-const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
-
-const cmd = [
-  'eslint',
-  '--no-eslintrc',
-  '--parser', '@typescript-eslint/parser',
-  '--plugin', 'test-flakiness',
-  '--rule', JSON.stringify(ruleConfig),
-];
-
-if (format) {
-  cmd.push('--format', format);
-}
-
-cmd.push(...eslintArgs);
-
+// Detect ESLint version to use the right approach
+let eslintMajor;
 try {
-  execSync(cmd.join(' '), {
-    stdio: 'inherit',
-    env: { ...process.env, NODE_PATH: globalRoot },
-  });
-} catch (e) {
-  process.exit(e.status || 1);
+  const eslintPkg = require('eslint/package.json');
+  eslintMajor = parseInt(eslintPkg.version.split('.')[0], 10);
+} catch (_e) {
+  console.error('Error: ESLint not found. Install it with: npm i -g eslint');
+  process.exit(1);
 }
+
+async function runWithNodeAPI() {
+  const plugin = require(path.join(__dirname, '..', 'lib', 'index.js'));
+
+  if (eslintMajor >= 9) {
+    // ESLint v9+ flat config via Node API
+    const { ESLint } = require('eslint');
+
+    let parser;
+    try {
+      parser = require('@typescript-eslint/parser');
+    } catch (_e) {
+      parser = undefined;
+    }
+
+    const overrideConfig = {
+      plugins: { 'test-flakiness': plugin },
+      rules: ruleConfig,
+    };
+
+    if (parser) {
+      overrideConfig.languageOptions = { parser };
+    }
+
+    const eslint = new ESLint({
+      overrideConfigFile: true,
+      overrideConfig,
+      fix,
+    });
+
+    const results = await eslint.lintFiles(filePatterns);
+
+    if (fix) {
+      await ESLint.outputFixes(results);
+    }
+
+    const formatter = await eslint.loadFormatter(format);
+    const output = formatter.format(results);
+    if (output) {
+      console.log(output);
+    }
+
+    const hasErrors = results.some(r => r.errorCount > 0);
+    const hasWarnings = results.some(r => r.warningCount > 0);
+    if (hasErrors) process.exit(1);
+    if (hasWarnings) process.exit(0);
+  } else {
+    // ESLint v7/v8 legacy CLI approach
+    let globalRoot;
+    try {
+      globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim();
+    } catch (_e) {
+      globalRoot = '';
+    }
+
+    const cmdArgs = [
+      '--no-eslintrc',
+      '--plugin', 'test-flakiness',
+      '--rule', JSON.stringify(ruleConfig),
+      '--format', format,
+    ];
+
+    try {
+      cmdArgs.push('--parser', require.resolve('@typescript-eslint/parser'));
+    } catch (_e) {
+      // Parser not available, skip
+    }
+
+    if (fix) {
+      cmdArgs.push('--fix');
+    }
+
+    cmdArgs.push(...filePatterns);
+
+    try {
+      execFileSync('eslint', cmdArgs, {
+        stdio: 'inherit',
+        env: { ...process.env, NODE_PATH: globalRoot },
+      });
+    } catch (e) {
+      process.exit(e.status || 1);
+    }
+  }
+}
+
+runWithNodeAPI().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/bin/lint-flaky.js
+++ b/bin/lint-flaky.js
@@ -113,10 +113,22 @@ async function runWithNodeAPI() {
       overrideConfig.languageOptions = { parser };
     }
 
+    // Resolve cwd to the common parent of all file patterns so ESLint
+    // doesn't reject files as "outside of base path"
+    const resolvedPatterns = filePatterns.map(p => path.resolve(p));
+    const commonDir = resolvedPatterns.reduce((dir, p) => {
+      const d = path.dirname(p);
+      while (!d.startsWith(dir)) {
+        dir = path.dirname(dir);
+      }
+      return dir;
+    }, path.dirname(resolvedPatterns[0]));
+
     const eslint = new ESLint({
       overrideConfigFile: true,
       overrideConfig,
       fix,
+      cwd: commonDir,
     });
 
     const results = await eslint.lintFiles(filePatterns);

--- a/bin/lint-flaky.js
+++ b/bin/lint-flaky.js
@@ -4,7 +4,6 @@
 
 const path = require('path');
 const fs = require('fs');
-const { execFileSync } = require('child_process');
 
 // Dynamically discover all rules from the plugin
 const rulesDir = path.join(__dirname, '..', 'lib', 'rules');
@@ -90,20 +89,53 @@ try {
   process.exit(1);
 }
 
+// Resolve cwd to the common parent of all file patterns so ESLint
+// doesn't reject files as "outside of base path"
+function resolveCommonDir(patterns) {
+  const resolved = patterns.map(p => path.resolve(p));
+  return resolved.reduce((dir, p) => {
+    const d = path.dirname(p);
+    while (!d.startsWith(dir)) {
+      dir = path.dirname(dir);
+    }
+    return dir;
+  }, path.dirname(resolved[0]));
+}
+
+async function formatAndExit(eslint, results) {
+  if (fix) {
+    const ESLintClass = eslint.constructor;
+    await ESLintClass.outputFixes(results);
+  }
+
+  const formatter = await eslint.loadFormatter(format);
+  const output = formatter.format
+    ? formatter.format(results)
+    : await formatter.format(results);
+  if (output) {
+    console.log(output);
+  }
+
+  const hasErrors = results.some(r => r.errorCount > 0);
+  if (hasErrors) process.exit(1);
+}
+
 async function runWithNodeAPI() {
   const plugin = require(path.join(__dirname, '..', 'lib', 'index.js'));
+  const { ESLint } = require('eslint');
+
+  let parser;
+  try {
+    parser = require('@typescript-eslint/parser');
+  } catch (_e) {
+    parser = undefined;
+  }
+
+  const commonDir = resolveCommonDir(filePatterns);
+  let eslint;
 
   if (eslintMajor >= 9) {
     // ESLint v9+ flat config via Node API
-    const { ESLint } = require('eslint');
-
-    let parser;
-    try {
-      parser = require('@typescript-eslint/parser');
-    } catch (_e) {
-      parser = undefined;
-    }
-
     const overrideConfig = {
       plugins: { 'test-flakiness': plugin },
       rules: ruleConfig,
@@ -113,77 +145,34 @@ async function runWithNodeAPI() {
       overrideConfig.languageOptions = { parser };
     }
 
-    // Resolve cwd to the common parent of all file patterns so ESLint
-    // doesn't reject files as "outside of base path"
-    const resolvedPatterns = filePatterns.map(p => path.resolve(p));
-    const commonDir = resolvedPatterns.reduce((dir, p) => {
-      const d = path.dirname(p);
-      while (!d.startsWith(dir)) {
-        dir = path.dirname(dir);
-      }
-      return dir;
-    }, path.dirname(resolvedPatterns[0]));
-
-    const eslint = new ESLint({
+    eslint = new ESLint({
       overrideConfigFile: true,
       overrideConfig,
       fix,
       cwd: commonDir,
     });
-
-    const results = await eslint.lintFiles(filePatterns);
-
-    if (fix) {
-      await ESLint.outputFixes(results);
-    }
-
-    const formatter = await eslint.loadFormatter(format);
-    const output = formatter.format(results);
-    if (output) {
-      console.log(output);
-    }
-
-    const hasErrors = results.some(r => r.errorCount > 0);
-    const hasWarnings = results.some(r => r.warningCount > 0);
-    if (hasErrors) process.exit(1);
-    if (hasWarnings) process.exit(0);
   } else {
-    // ESLint v7/v8 legacy CLI approach
-    let globalRoot;
-    try {
-      globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim();
-    } catch (_e) {
-      globalRoot = '';
+    // ESLint v7/v8 Node API
+    const overrideConfig = {
+      plugins: ['test-flakiness'],
+      rules: ruleConfig,
+    };
+
+    if (parser) {
+      overrideConfig.parser = require.resolve('@typescript-eslint/parser');
     }
 
-    const cmdArgs = [
-      '--no-eslintrc',
-      '--plugin', 'test-flakiness',
-      '--rule', JSON.stringify(ruleConfig),
-      '--format', format,
-    ];
-
-    try {
-      cmdArgs.push('--parser', require.resolve('@typescript-eslint/parser'));
-    } catch (_e) {
-      // Parser not available, skip
-    }
-
-    if (fix) {
-      cmdArgs.push('--fix');
-    }
-
-    cmdArgs.push(...filePatterns);
-
-    try {
-      execFileSync('eslint', cmdArgs, {
-        stdio: 'inherit',
-        env: { ...process.env, NODE_PATH: globalRoot },
-      });
-    } catch (e) {
-      process.exit(e.status || 1);
-    }
+    eslint = new ESLint({
+      useEslintrc: false,
+      overrideConfig,
+      fix,
+      cwd: commonDir,
+      plugins: { 'test-flakiness': plugin },
+    });
   }
+
+  const results = await eslint.lintFiles(filePatterns);
+  await formatAndExit(eslint, results);
 }
 
 runWithNodeAPI().catch((err) => {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,13 @@
     "commit": "cz",
     "semantic-release": "semantic-release"
   },
+  "bin": {
+    "lint-flaky": "./bin/lint-flaky.js"
+  },
   "files": [
     "lib/**/*.js",
     "lib/**/*.d.ts",
+    "bin/**/*.js",
     "package.json",
     "README.md",
     "LICENSE"

--- a/tests/bin/lint-flaky.test.js
+++ b/tests/bin/lint-flaky.test.js
@@ -1,0 +1,192 @@
+/* eslint-disable test-flakiness/no-unmocked-fs, test-flakiness/no-test-isolation */
+'use strict';
+
+const { execFile } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const BIN_PATH = path.join(__dirname, '..', '..', 'bin', 'lint-flaky.js');
+const FIXTURES_DIR = path.join(os.tmpdir(), 'lint-flaky-test-fixtures');
+
+function run(args = [], options = {}) {
+  return new Promise((resolve) => {
+    execFile(process.execPath, [BIN_PATH, ...args], {
+      timeout: 30000,
+      ...options,
+    }, (error, stdout, stderr) => {
+      resolve({
+        exitCode: error ? error.code : 0,
+        stdout: stdout.toString(),
+        stderr: stderr.toString(),
+      });
+    });
+  });
+}
+
+beforeAll(() => {
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+
+  // A clean file with no flaky patterns
+  fs.writeFileSync(
+    path.join(FIXTURES_DIR, 'clean.test.js'),
+    `describe('clean tests', () => {
+  it('should pass', () => {
+    expect(true).toBe(true);
+  });
+});
+`
+  );
+
+  // A file with a flaky pattern (hard-coded timeout)
+  fs.writeFileSync(
+    path.join(FIXTURES_DIR, 'flaky.test.js'),
+    `describe('flaky tests', () => {
+  it('should wait', async () => {
+    await new Promise(resolve => setTimeout(resolve, 5000));
+  });
+});
+`
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+});
+
+describe('lint-flaky CLI', () => {
+  describe('help and usage', () => {
+    it('shows help with --help flag', async () => {
+      const { stdout, exitCode } = await run(['--help']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Usage: lint-flaky');
+      expect(stdout).toContain('--fix');
+      expect(stdout).toContain('--severity');
+      expect(stdout).toContain('--format');
+      expect(stdout).toContain('Available rules');
+    });
+
+    it('shows help with -h flag', async () => {
+      const { stdout, exitCode } = await run(['-h']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Usage: lint-flaky');
+    });
+
+    it('shows usage and exits with code 1 when no args', async () => {
+      const { stdout, exitCode } = await run([]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('Usage: lint-flaky');
+    });
+
+    it('lists all available rules in help', async () => {
+      const { stdout } = await run(['--help']);
+      expect(stdout).toContain('test-flakiness/no-hard-coded-timeout');
+      expect(stdout).toContain('test-flakiness/no-unconditional-wait');
+      expect(stdout).toContain('test-flakiness/await-async-events');
+      expect(stdout).toContain('test-flakiness/no-test-focus');
+    });
+  });
+
+  describe('severity validation', () => {
+    it('rejects invalid severity', async () => {
+      const { stderr, exitCode } = await run(['--severity', 'invalid', 'file.js']);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain('Invalid severity "invalid"');
+      expect(stderr).toContain('warn, error, off');
+    });
+
+    it('accepts warn severity', async () => {
+      const { stderr } = await run(['--severity', 'warn', path.join(FIXTURES_DIR, 'clean.test.js')]);
+      expect(stderr).not.toContain('Invalid severity');
+    });
+
+    it('accepts error severity', async () => {
+      const { stderr } = await run(['--severity', 'error', path.join(FIXTURES_DIR, 'clean.test.js')]);
+      expect(stderr).not.toContain('Invalid severity');
+    });
+
+    it('accepts off severity', async () => {
+      const { stderr } = await run(['--severity', 'off', path.join(FIXTURES_DIR, 'clean.test.js')]);
+      expect(stderr).not.toContain('Invalid severity');
+    });
+  });
+
+  describe('argument parsing', () => {
+    it('treats non-option args as file patterns', async () => {
+      // Should not show "no file patterns" error
+      const { stderr } = await run([path.join(FIXTURES_DIR, 'clean.test.js')]);
+      expect(stderr).not.toContain('No file patterns specified');
+    });
+
+    it('parses --fix flag without error', async () => {
+      const { stderr } = await run(['--fix', path.join(FIXTURES_DIR, 'clean.test.js')]);
+      expect(stderr).not.toContain('No file patterns specified');
+    });
+
+    it('parses --format option', async () => {
+      const { stderr } = await run(['--format', 'json', path.join(FIXTURES_DIR, 'clean.test.js')]);
+      expect(stderr).not.toContain('No file patterns specified');
+    });
+
+    it('parses multiple options together', async () => {
+      const { stderr } = await run([
+        '--severity', 'error',
+        '--fix',
+        '--format', 'json',
+        path.join(FIXTURES_DIR, 'clean.test.js'),
+      ]);
+      expect(stderr).not.toContain('Invalid severity');
+      expect(stderr).not.toContain('No file patterns specified');
+    });
+  });
+
+  describe('linting behavior', () => {
+    it('exits 0 for a clean file with no flaky patterns', async () => {
+      const { exitCode } = await run([
+        '--severity', 'off',
+        path.join(FIXTURES_DIR, 'clean.test.js'),
+      ]);
+      expect(exitCode).toBe(0);
+    });
+
+    it('detects flaky patterns in test files', async () => {
+      const { stdout } = await run([
+        '--format', 'json',
+        path.join(FIXTURES_DIR, 'flaky.test.js'),
+      ]);
+      const results = JSON.parse(stdout);
+      expect(results).toBeInstanceOf(Array);
+      expect(results.length).toBeGreaterThan(0);
+
+      const messages = results[0].messages;
+      expect(messages.length).toBeGreaterThan(0);
+
+      const ruleIds = messages.map(m => m.ruleId).filter(Boolean);
+      expect(ruleIds.some(id => id.startsWith('test-flakiness/'))).toBe(true);
+    });
+
+    it('reports errors when severity is error', async () => {
+      const { exitCode, stdout } = await run([
+        '--severity', 'error',
+        '--format', 'json',
+        path.join(FIXTURES_DIR, 'flaky.test.js'),
+      ]);
+      expect(exitCode).toBe(1);
+
+      const results = JSON.parse(stdout);
+      const messages = results[0].messages;
+      expect(messages.some(m => m.severity === 2)).toBe(true);
+    });
+
+    it('reports no issues when severity is off', async () => {
+      const { stdout } = await run([
+        '--severity', 'off',
+        '--format', 'json',
+        path.join(FIXTURES_DIR, 'flaky.test.js'),
+      ]);
+      const results = JSON.parse(stdout);
+      const messages = results[0].messages.filter(m => m.ruleId !== null);
+      expect(messages.length).toBe(0);
+    });
+  });
+});

--- a/tests/bin/lint-flaky.test.js
+++ b/tests/bin/lint-flaky.test.js
@@ -6,6 +6,10 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
+// lint-flaky CLI requires ESLint 9+ (uses flat config Node API)
+const eslintMajor = parseInt(require('eslint/package.json').version.split('.')[0], 10);
+const describeIfEslint9 = eslintMajor >= 9 ? describe : describe.skip;
+
 const BIN_PATH = path.join(__dirname, '..', '..', 'bin', 'lint-flaky.js');
 const FIXTURES_DIR = path.join(os.tmpdir(), 'lint-flaky-test-fixtures');
 
@@ -54,7 +58,7 @@ afterAll(() => {
   fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
 });
 
-describe('lint-flaky CLI', () => {
+describeIfEslint9('lint-flaky CLI', () => {
   describe('help and usage', () => {
     it('shows help with --help flag', async () => {
       const { stdout, exitCode } = await run(['--help']);


### PR DESCRIPTION
## Existing Behavior

- The plugin only works as an ESLint config dependency — users must configure it in their `.eslintrc` or `eslint.config.mjs` to lint test files.
- There is no standalone CLI entry point; running the plugin globally with `npm install -g` provides no executable.
- Rule discovery is entirely manual — users must know the rule names to configure them individually.

## Intended New Behavior

- A new `bin/lint-flaky.js` executable is registered as `lint-flaky` in `package.json`, enabling `lint-flaky 'glob-pattern'` after a global install.
- The CLI dynamically discovers all rules from `lib/rules/` at runtime, so new rules are automatically included without updating the CLI.
- Users can override severity (`--severity error|warn`), apply autofixes (`--fix`), and choose an ESLint formatter (`--format <name>`) via CLI flags.
- `bin/**/*.js` is added to the `files` field in `package.json` so the CLI is included in published npm packages.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

After installing globally:

```bash
npm install -g eslint-plugin-test-flakiness
```

1. Run with no arguments to verify help output and rule listing:
   ```bash
   lint-flaky
   ```
   Expected: prints usage, options, and lists all discovered `test-flakiness/*` rules.

2. Run against a glob of test files in any project:
   ```bash
   lint-flaky "src/**/*.spec.ts"
   ```
   Expected: ESLint output showing flaky test warnings using all plugin rules at `warn` severity.

3. Run with `--severity error` to treat violations as errors:
   ```bash
   lint-flaky --severity error "src/**/*.spec.ts"
   ```
   Expected: exits with code 1 when violations are found.

4. Run with `--fix` to apply autofixes:
   ```bash
   lint-flaky --fix "src/**/*.spec.ts"
   ```
   Expected: fixable violations are applied in-place.

5. Verify `--help` flag exits cleanly with code 0:
   ```bash
   lint-flaky --help
   ```
   Expected: prints help text and exits 0.

> Note: This branch has conflicts with `main` that require manual resolution before merging. The conflicts are in `eslint.config.mjs`, several `lib/rules/` files, and test files due to upstream rule changes merged to `main` after this branch diverged.