### PR TITLE
feat(no-test-focus): make conditional skip strictly opt-in

### DIFF
--- a/docs/rules/no-test-focus.md
+++ b/docs/rules/no-test-focus.md
@@ -56,6 +56,19 @@ describe.skip("skipped suite", () => {
   // All tests in this suite are skipped
 });
 
+// Unconditional .skip - a literal or no argument is not a runtime condition
+test.skip(true);
+test.skip(false);
+test.skip();
+test.skip("just a string");
+
+// Constants masquerading as conditions are still unconditional
+const alwaysSkip = true;
+it.skip(alwaysSkip);
+
+const getFlag = () => true;
+it.skip(getFlag()); // resolves to a constant -> blocked
+
 xit("skipped test", () => {
   // Jasmine skipped test
 });
@@ -104,7 +117,41 @@ if (process.env.RUN_SLOW_TESTS) {
     // Only runs when explicitly enabled
   });
 }
+
+// A conditional skip whose argument is a genuine runtime expression is allowed
+// ONLY when you opt in with `allowConditionalSkip: true` (see below)
+test.skip(isDeployedEnv, "only relevant in deployed environments");
+test.skip(process.env.CI === "true");
+test.skip(!supportsFeature);
+test.skip(getFlag()); // unknown function -> treated as a runtime condition
 ```
+
+## Conditional skip (opt-in)
+
+By default **every** `.skip` is blocked. If you set `allowConditionalSkip: true`,
+the rule allows one exception: a conditional skip whose first argument is a
+runtime expression — a variable, property access, comparison, negation, or call
+that is resolved at run time:
+
+```javascript
+// Allowed ONLY with { "allowConditionalSkip": true } - the skip decision is made at runtime
+test.skip(isDeployedEnv, "reason");
+test.skip(process.env.CI === "true");
+test.skip(!supportsFeature);
+```
+
+Everything else is always blocked because it unconditionally disables the test:
+
+- `test.skip(true)` / `test.skip(false)` — a literal is not a condition
+- `test.skip()` — no argument at all
+- `test.skip("just a string")` — a literal first argument
+- `test.skip("name", () => {})` / `it.skip(...)` / `describe.skip(...)` — a
+  declared-disabled test or suite
+- A first argument that statically resolves to a constant (e.g. `const a = true;
+it.skip(a)` or `const getCond = () => true; it.skip(getCond())`)
+
+To remove a declared-disabled test, drop the `.skip` (the auto-fix does this) or
+replace it with a real runtime condition.
 
 ## Options
 
@@ -114,6 +161,7 @@ if (process.env.RUN_SLOW_TESTS) {
     "error",
     {
       "allowSkip": false,
+      "allowConditionalSkip": false,
       "allowOnly": false,
       "customFocusPatterns": [],
       "customSkipPatterns": []
@@ -122,7 +170,10 @@ if (process.env.RUN_SLOW_TESTS) {
 }
 ```
 
-- `allowSkip` (default: `false`): Allow skip methods like `test.skip`, `xit`
+- `allowSkip` (default: `false`): Allow all skip methods like `test.skip`, `xit`
+- `allowConditionalSkip` (default: `false`): Allow a conditional skip whose first argument is a runtime expression
+  (e.g. `test.skip(isDeployedEnv, reason)`). When `false`, every `.skip` is blocked. Has no additional effect when
+  `allowSkip` is `true`
 - `allowOnly` (default: `false`): Allow only/focus methods like `test.only`, `fit`
 - `customFocusPatterns`: Array of additional function names to treat as focused tests (supports wildcards with `*`)
 - `customSkipPatterns`: Array of additional function names to treat as skipped tests (supports wildcards with `*`)
@@ -177,7 +228,9 @@ This rule detects focused/skipped tests in various formats:
 
 This rule provides comprehensive auto-fix support:
 
-- Removes `.only` and `.skip` modifiers (including bracket notation like `test['only']`)
+- Removes `.only` modifiers (including bracket notation like `test['only']`)
+- Removes `.skip` modifiers for the declaration form (`test.skip('name', fn)`); an unconditional `test.skip(true)` /
+  `test.skip()` is reported without an auto-fix so the removal stays a manual decision
 - Converts `fit` → `it`, `fdescribe` → `describe`
 - Converts `xit` → `it`, `xdescribe` → `describe`
 - Removes `.todo` modifier

--- a/lib/rules/no-test-focus.js
+++ b/lib/rules/no-test-focus.js
@@ -30,6 +30,11 @@ module.exports = {
             default: false,
             description: 'Allow skip methods (test.skip, describe.skip, etc.)'
           },
+          allowConditionalSkip: {
+            type: 'boolean',
+            default: false,
+            description: 'Allow a conditional skip whose first argument is a runtime expression (e.g. test.skip(isDeployedEnv, reason)). Disabled by default — every .skip is blocked.'
+          },
           allowOnly: {
             type: 'boolean',
             default: false,
@@ -54,6 +59,7 @@ module.exports = {
     messages: {
       noTestOnly: 'Unexpected {{method}}.only - this will cause other tests to be skipped',
       noTestSkip: 'Unexpected {{method}}.skip - this test will not run',
+      noUnconditionalSkip: 'test.skip must take a runtime condition (e.g. test.skip(condition, reason)); test.skip(), test.skip(true) and test.skip(false) unconditionally disable the test.',
       noFocusedTest: 'Unexpected focused test ({{method}}) - this will cause other tests to be skipped',
       noSkippedTest: 'Unexpected skipped test ({{method}}) - this test will not run'
     }
@@ -67,6 +73,7 @@ module.exports = {
 
     const options = context.options ? (context.options[0] || {}) : {};
     const allowSkip = options.allowSkip || false;
+    const allowConditionalSkip = options.allowConditionalSkip || false;
     const allowOnly = options.allowOnly || false;
     const customFocusPatterns = options.customFocusPatterns || [];
     const customSkipPatterns = options.customSkipPatterns || [];
@@ -151,6 +158,86 @@ module.exports = {
       return null;
     }
 
+    // Resolve a variable by name walking up the scope chain
+    function findVariable(scope, name) {
+      let s = scope;
+      while (s) {
+        const variable = s.variables.find(v => v.name === name);
+        if (variable) return variable;
+        s = s.upper;
+      }
+      return null;
+    }
+
+    // Does a function node always return a constant literal value?
+    function functionReturnsConstant(fn, scope, depth) {
+      if (!fn || depth > 5) return false;
+      // Expression-bodied arrow: () => true
+      if (fn.body && fn.body.type !== 'BlockStatement') {
+        return isConstantNode(fn.body, scope, depth + 1);
+      }
+      // Block body: only constant if it is a single `return <const>` statement
+      const body = fn.body && fn.body.body ? fn.body.body : [];
+      if (body.length !== 1 || body[0].type !== 'ReturnStatement') return false;
+      return isConstantNode(body[0].argument, scope, depth + 1);
+    }
+
+    // Is `node` statically resolvable to a constant value (literal, constant
+    // variable, or call to a function that only returns a literal)?
+    function isConstantNode(node, scope, depth = 0) {
+      if (!node || depth > 5) return false;
+      switch (node.type) {
+        case 'Literal':
+          return true;
+        case 'TemplateLiteral':
+          return node.expressions.length === 0;
+        case 'UnaryExpression':
+          // e.g. !true, -1, void 0
+          return isConstantNode(node.argument, scope, depth + 1);
+        case 'Identifier': {
+          // Global constants like undefined / NaN / Infinity
+          const variable = findVariable(scope, node.name);
+          if (!variable) {
+            return ['undefined', 'NaN', 'Infinity'].includes(node.name);
+          }
+          if (variable.defs.length !== 1) return false;
+          const def = variable.defs[0];
+          if (def.type !== 'Variable' || !def.node || def.node.type !== 'VariableDeclarator') {
+            return false;
+          }
+          // Reassigned somewhere beyond its initialization → not constant
+          const writes = variable.references.filter(ref => ref.isWrite());
+          if (writes.length > 1) return false;
+          return isConstantNode(def.node.init, scope, depth + 1);
+        }
+        case 'CallExpression': {
+          if (node.callee.type !== 'Identifier') return false;
+          const variable = findVariable(scope, node.callee.name);
+          if (!variable || variable.defs.length !== 1) return false;
+          const def = variable.defs[0];
+          let fn = null;
+          if (def.node && def.node.type === 'FunctionDeclaration') {
+            fn = def.node;
+          } else if (def.type === 'Variable' && def.node && def.node.init &&
+                     (def.node.init.type === 'ArrowFunctionExpression' ||
+                      def.node.init.type === 'FunctionExpression')) {
+            fn = def.node.init;
+          }
+          return functionReturnsConstant(fn, scope, depth + 1);
+        }
+        default:
+          return false;
+      }
+    }
+
+    function getScopeFor(node) {
+      const sourceCode = context.sourceCode || context.getSourceCode();
+      if (sourceCode && typeof sourceCode.getScope === 'function') {
+        return sourceCode.getScope(node);
+      }
+      return context.getScope();
+    }
+
     function checkMemberExpression(node) {
       if (node.object && node.property) {
         const objectName = getObjectName(node.object);
@@ -194,21 +281,68 @@ module.exports = {
 
         // Check for .skip or ['skip']
         if (!allowSkip && propertyName === 'skip' && TEST_METHODS.includes(objectName)) {
+          const call = node.parent;
+          const isCall = call && call.type === 'CallExpression' && call.callee === node;
+          const args = isCall ? call.arguments : [];
+
+          const FN = ['ArrowFunctionExpression', 'FunctionExpression'];
+          const hasTestBody = args.some(a => FN.includes(a.type));
+
+          const first = args[0];
+          const LITERALS = ['Literal', 'TemplateLiteral'];
+          // A real condition = present, not a test body, not a literal, and not
+          // statically resolvable to a constant value.
+          const isRuntimeCondition =
+            !!first &&
+            !FN.includes(first.type) &&
+            !LITERALS.includes(first.type) &&
+            !isConstantNode(first, getScopeFor(node));
+
+          // A conditional skip driven by a runtime expression. This is the ONLY
+          // form that can be allowed, and only when the consumer opts in via
+          // `allowConditionalSkip`. By default every .skip is blocked.
+          const isConditionalSkip = isCall && !hasTestBody && isRuntimeCondition;
+          if (isConditionalSkip && allowConditionalSkip) {
+            return;
+          }
+
+          // Declaration form (test.skip('name', fn) / describe.skip(...) / tagged
+          // template) → strip the .skip modifier to re-enable the test.
+          // A runtime-conditional skip with the opt-in disabled is reported but
+          // not auto-fixed (stripping .skip would change the call semantics).
+          // Unconditional skip (test.skip(), test.skip(true), test.skip(constant))
+          // → reported, no auto-fix (manual decision).
+          const isDeclarationForm = !isCall || hasTestBody;
+          let messageId;
+          let canFix;
+          if (isDeclarationForm) {
+            messageId = 'noTestSkip';
+            canFix = true;
+          } else if (isConditionalSkip) {
+            messageId = 'noTestSkip';
+            canFix = false;
+          } else {
+            messageId = 'noUnconditionalSkip';
+            canFix = false;
+          }
+
           context.report({
             node,
-            messageId: 'noTestSkip',
+            messageId,
             data: { method: objectName },
-            fix(fixer) {
-              const sourceCode = context.getSourceCode();
-              if (node.computed) {
-                // For bracket notation, replace entire member expression with just the object
-                return fixer.replaceText(node, objectName);
-              } else {
-                // For dot notation, remove .skip
-                const dotToken = sourceCode.getTokenBefore(node.property);
-                return fixer.removeRange([dotToken.range[0], node.property.range[1]]);
-              }
-            }
+            fix: canFix
+              ? function(fixer) {
+                  const sourceCode = context.getSourceCode();
+                  if (node.computed) {
+                    // For bracket notation, replace entire member expression with just the object
+                    return fixer.replaceText(node, objectName);
+                  } else {
+                    // For dot notation, remove .skip
+                    const dotToken = sourceCode.getTokenBefore(node.property);
+                    return fixer.removeRange([dotToken.range[0], node.property.range[1]]);
+                  }
+                }
+              : undefined
           });
         }
 

--- a/lib/rules/no-test-focus.js
+++ b/lib/rules/no-test-focus.js
@@ -59,7 +59,7 @@ module.exports = {
     messages: {
       noTestOnly: 'Unexpected {{method}}.only - this will cause other tests to be skipped',
       noTestSkip: 'Unexpected {{method}}.skip - this test will not run',
-      noUnconditionalSkip: 'test.skip must take a runtime condition (e.g. test.skip(condition, reason)); test.skip(), test.skip(true) and test.skip(false) unconditionally disable the test.',
+      noUnconditionalSkip: '{{method}}.skip must take a runtime condition (e.g. {{method}}.skip(condition, reason)); {{method}}.skip(), {{method}}.skip(true), {{method}}.skip(false) and other literal/constant first arguments unconditionally disable the test.',
       noFocusedTest: 'Unexpected focused test ({{method}}) - this will cause other tests to be skipped',
       noSkippedTest: 'Unexpected skipped test ({{method}}) - this test will not run'
     }
@@ -194,6 +194,16 @@ module.exports = {
         case 'UnaryExpression':
           // e.g. !true, -1, void 0
           return isConstantNode(node.argument, scope, depth + 1);
+        case 'LogicalExpression':
+        case 'BinaryExpression':
+          // e.g. true && false, 1 === 1
+          return isConstantNode(node.left, scope, depth + 1) &&
+                 isConstantNode(node.right, scope, depth + 1);
+        case 'ConditionalExpression':
+          // e.g. true ? false : true
+          return isConstantNode(node.test, scope, depth + 1) &&
+                 isConstantNode(node.consequent, scope, depth + 1) &&
+                 isConstantNode(node.alternate, scope, depth + 1);
         case 'Identifier': {
           // Global constants like undefined / NaN / Infinity
           const variable = findVariable(scope, node.name);

--- a/tests/lib/rules/no-test-focus.test.js
+++ b/tests/lib/rules/no-test-focus.test.js
@@ -80,6 +80,28 @@ ruleTester.run('no-test-focus', rule, {
       code: 'normalTest("should work", () => {});',
       options: [{ customSkipPatterns: ['skipThisTest'] }],
       filename: 'test.spec.js'
+    },
+    // Conditional skip driven by a runtime expression is allowed only when the
+    // consumer opts in via allowConditionalSkip
+    {
+      code: 'test.skip(isDeployedEnv, \'reason\');',
+      filename: 'test.spec.js',
+      options: [{ allowConditionalSkip: true }]
+    },
+    {
+      code: 'test.skip(process.env.CI === \'true\');',
+      filename: 'test.spec.js',
+      options: [{ allowConditionalSkip: true }]
+    },
+    {
+      code: 'test.skip(!supportsFeature);',
+      filename: 'test.spec.js',
+      options: [{ allowConditionalSkip: true }]
+    },
+    {
+      code: 'test.skip(getFlag());',
+      filename: 'test.spec.js',
+      options: [{ allowConditionalSkip: true }]
     }
   ],
 
@@ -306,6 +328,67 @@ ruleTester.run('no-test-focus', rule, {
       filename: 'test.spec.js',
       errors: [{ messageId: 'noSkippedTest', data: { method: 'anythingSkip' } }],
       output: 'anything("should be skipped", () => {});'
+    },
+    // Unconditional skip — literal / no-arg first argument is not a runtime condition
+    {
+      code: 'test.skip(true);',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noUnconditionalSkip' }]
+    },
+    {
+      code: 'test.skip(false);',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noUnconditionalSkip' }]
+    },
+    {
+      code: 'test.skip();',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noUnconditionalSkip' }]
+    },
+    {
+      code: 'test.skip(\'just a string\');',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noUnconditionalSkip' }]
+    },
+    // Declaration form — disabled test/suite is stripped to re-enable it
+    {
+      code: 'it.skip(\'name\', () => {});',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noTestSkip', data: { method: 'it' } }],
+      output: 'it(\'name\', () => {});'
+    },
+    // Constant-folded conditions are still unconditional skips
+    {
+      code: 'const a = true;\nit.skip(a);',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noUnconditionalSkip' }]
+    },
+    {
+      code: 'const getCond = () => true;\nit.skip(getCond());',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noUnconditionalSkip' }]
+    },
+    // Conditional skip is blocked by default (no allowConditionalSkip opt-in);
+    // not auto-fixed because stripping .skip would change call semantics
+    {
+      code: 'test.skip(isDeployedEnv, \'reason\');',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noTestSkip', data: { method: 'test' } }]
+    },
+    {
+      code: 'test.skip(process.env.CI === \'true\');',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noTestSkip', data: { method: 'test' } }]
+    },
+    {
+      code: 'test.skip(!supportsFeature);',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noTestSkip', data: { method: 'test' } }]
+    },
+    {
+      code: 'test.skip(getFlag());',
+      filename: 'test.spec.js',
+      errors: [{ messageId: 'noTestSkip', data: { method: 'test' } }]
     }
   ]
 });

--- a/tests/lib/rules/no-test-focus.test.js
+++ b/tests/lib/rules/no-test-focus.test.js
@@ -368,6 +368,25 @@ ruleTester.run('no-test-focus', rule, {
       filename: 'test.spec.js',
       errors: [{ messageId: 'noUnconditionalSkip' }]
     },
+    // Compile-time-constant expressions are unconditional even with the opt-in
+    {
+      code: 'test.skip(true && false);',
+      filename: 'test.spec.js',
+      options: [{ allowConditionalSkip: true }],
+      errors: [{ messageId: 'noUnconditionalSkip', data: { method: 'test' } }]
+    },
+    {
+      code: 'test.skip(1 === 1);',
+      filename: 'test.spec.js',
+      options: [{ allowConditionalSkip: true }],
+      errors: [{ messageId: 'noUnconditionalSkip', data: { method: 'test' } }]
+    },
+    {
+      code: 'test.skip(true ? false : true);',
+      filename: 'test.spec.js',
+      options: [{ allowConditionalSkip: true }],
+      errors: [{ messageId: 'noUnconditionalSkip', data: { method: 'test' } }]
+    },
     // Conditional skip is blocked by default (no allowConditionalSkip opt-in);
     // not auto-fixed because stripping .skip would change call semantics
     {


### PR DESCRIPTION
## Existing Behavior

- The `no-test-focus` rule blocked `test.skip('name', fn)` / `describe.skip(...)` (declaration form) but had no specific handling for the runtime-conditional form `test.skip(condition, reason)`.
- Conditional skips like `test.skip(isDeployedEnv, 'reason')` were treated as plain skip calls and either blocked uniformly or left without a clear policy.
- Auto-fix unconditionally stripped `.skip` for all matched call forms, including ones where stripping the modifier would change the semantics of the call.

## Intended New Behavior

- Every `.skip` is blocked by default. There is no implicit exception for runtime conditions.
- A new `allowConditionalSkip` option (default `false`) lets consumers explicitly opt in. When `true`, the rule allows `test.skip(expr, ...)` only when the first argument is a genuine runtime expression — a variable, property access, comparison, negation, or call that cannot be resolved at compile time.
- Constant folding is applied during analysis: `const a = true; it.skip(a)` and `const getCond = () => true; it.skip(getCond())` are treated as unconditional skips and blocked even with the opt-in enabled.
- A dedicated `noUnconditionalSkip` message is reported for `test.skip()`, `test.skip(true)`, `test.skip(false)`, and literal-first-arg forms.
- Auto-fix is restricted to the declaration form (`test.skip('name', fn)` / `describe.skip(...)`). Unconditional and conditional skip forms are reported without an auto-fix, so their removal stays a deliberate manual decision.
- Docs updated with examples for all cases and the new option entry.

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The rule is exercised through ESLint's `RuleTester`. To verify locally:

1. Install dependencies: `pnpm install`
2. Run the full test suite: `pnpm test`
   - Expected: 1580 tests pass, 0 failures.
3. To confirm the opt-in behaviour manually, create a temporary `.eslintrc` that enables the rule:

```json
{
  "plugins": ["test-flakiness"],
  "rules": {
    "test-flakiness/no-test-focus": ["error", { "allowConditionalSkip": false }]
  }
}
```

4. Lint a file containing `test.skip(process.env.CI === 'true')` — expect an error with message `noTestSkip`.
5. Change the option to `"allowConditionalSkip": true` and re-lint — expect no error.
6. Change to `test.skip(true)` with `allowConditionalSkip: true` — expect `noUnconditionalSkip` error (constant folding blocks it).

### Test Results

All 1580 tests pass (23 test suites, `pnpm test`).