### PR TITLE
ci: publish to npm via OIDC trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,21 @@ jobs:
         run: pnpm run test:ci
 
       - name: Run semantic-release
+        id: semantic_release
         if: steps.code-changes.outputs.has_code_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: 0
         run: pnpm run semantic-release
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; Node 22 ships an older npm.
+      - name: Upgrade npm for OIDC trusted publishing
+        if: steps.semantic_release.outputs.new-release-published == 'true'
+        run: npm install -g npm@latest
+
+      # Tokenless publish: npm exchanges the GitHub OIDC id-token (id-token: write,
+      # already granted above) for a short-lived, single-use credential. No NPM_TOKEN.
+      # Requires a one-time Trusted Publisher config on npmjs.com (see README/repo notes).
+      - name: Publish to npm (OIDC, tokenless)
+        if: steps.semantic_release.outputs.new-release-published == 'true'
+        run: npm publish --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,4 +138,9 @@ jobs:
       # Requires a one-time Trusted Publisher config on npmjs.com (see README/repo notes).
       - name: Publish to npm (OIDC, tokenless)
         if: steps.semantic_release.outputs.new-release-published == 'true'
-        run: npm publish --provenance --access public
+        run: |
+          # actions/setup-node writes `_authToken=${NODE_AUTH_TOKEN}` into the npmrc it
+          # manages (NPM_CONFIG_USERCONFIG); with no token that empty value shadows OIDC.
+          # Remove it so npm uses the GitHub OIDC id-token for trusted publishing.
+          npm config delete //registry.npmjs.org/:_authToken 2>/dev/null || true
+          npm publish --provenance --access public

--- a/.npmrc
+++ b/.npmrc
@@ -2,6 +2,5 @@
 auto-install-peers=true
 strict-peer-dependencies=false
 
-# Publishing configuration
-# The auth token will be set by GitHub Actions
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+# Publishing uses npm OIDC Trusted Publishing in CI (.github/workflows/ci.yml);
+# no static auth token is configured here so npm falls back to the GitHub OIDC id-token.

--- a/.releaserc
+++ b/.releaserc
@@ -39,7 +39,7 @@
     }],
     "@semantic-release/changelog",
     ["@semantic-release/npm", {
-      "npmPublish": true
+      "npmPublish": false
     }],
     ["@semantic-release/github"]
   ]


### PR DESCRIPTION
## Existing Behavior

- The release job authenticates to npm using a long-lived `NPM_TOKEN` secret passed as `NODE_AUTH_TOKEN` to the `semantic-release` step.
- `@semantic-release/npm` handles npm publishing directly inside semantic-release with `npmPublish: true`, requiring the secret to be present or it throws `ENONPMTOKEN` and aborts.
- The `NPM_TOKEN` secret is stored in the repo and must be manually rotated before expiry.

## Intended New Behavior

- `@semantic-release/npm` is set to `npmPublish: false`; semantic-release still manages version bumping, changelog generation, git tagging, and GitHub release creation — it just no longer publishes to npm and no longer requires a token.
- After a successful semantic-release run, npm is upgraded to >= 11.5.1 (required for OIDC trusted publishing; Node 22 ships an older version).
- A new `npm publish --provenance --access public` step, gated on `new-release-published == 'true'`, publishes tokenlessly via GitHub OIDC — the job's existing `id-token: write` permission mints a short-lived, single-use credential at publish time. No stored secret is consumed.
- `NPM_TOKEN` and `NODE_AUTH_TOKEN` are removed from the semantic-release step's `env` block entirely.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a CI/CD configuration change. Verification steps:

1. Merge this PR and create a commit that triggers a release (any commit matching the semantic-release rules on `main`).
2. Observe the Actions run for the `ci` workflow — the `Run semantic-release` step should complete without `ENONPMTOKEN`.
3. Confirm the `Upgrade npm for OIDC trusted publishing` step runs and exits 0.
4. Confirm the `Publish to npm (OIDC, tokenless)` step runs and exits 0 — the npm registry should show the new version with provenance attestation at `https://www.npmjs.com/package/eslint-plugin-test-flakiness`.
5. If no release is triggered, both post-release steps are skipped (gated on `new-release-published == 'true'`) — this is expected and correct.

Pre-merge prerequisite: Trusted Publisher must be configured on npmjs.com for this repository and workflow file. If an `Environment` field was set during that configuration, the job's `environment: NPM_TOKEN` value must match it exactly. The `NPM_TOKEN` repo secret is now unused and can be deleted after confirming a successful OIDC publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release publishing is reimplemented outside semantic-release; a misconfigured npm Trusted Publisher or failed OIDC/auth cleanup could block or break publishes until fixed.
> 
> **Overview**
> **npm publishing moves out of semantic-release** and onto a dedicated CI path that uses **GitHub OIDC trusted publishing** instead of a stored `NPM_TOKEN`.
> 
> `@semantic-release/npm` is set to **`npmPublish: false`**, so semantic-release still bumps versions, updates the changelog, tags, and creates GitHub releases but no longer publishes or requires npm credentials. The release job drops **`NPM_TOKEN` / `NODE_AUTH_TOKEN`** from the semantic-release step and gives that step an **`id`** so later steps can gate on **`new-release-published`**.
> 
> When a release is actually published, CI **upgrades npm** (for OIDC support on Node 22), **strips any empty `_authToken`** that `setup-node` may have written, then runs **`npm publish --provenance --access public`**. Repo **`.npmrc` no longer configures a registry auth token**, so local/CI config does not override OIDC in the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca8ac40ac255fbe3ecbdd3ac5d69939ebf9c9d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->