### PR TITLE
fix(package): normalize lint-flaky bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "semantic-release": "semantic-release"
   },
   "bin": {
-    "lint-flaky": "./bin/lint-flaky.js"
+    "lint-flaky": "bin/lint-flaky.js"
   },
   "files": [
     "lib/**/*.js",


### PR DESCRIPTION
## Existing Behavior

The `bin` field in `package.json` declared the entry point as `./bin/lint-flaky.js` (with a leading `./`). npm normalizes this to `bin/lint-flaky.js` at publish time and emits a warning during `npm publish`.

## Intended New Behavior

The leading `./` is dropped so the source manifest matches npm's expected form. The warning no longer fires on publish. There is no behavior change — the published 1.5.0 artifact already had the corrected bin path, so the CLI continues to work exactly as before.

The repository/bugs/homepage owner URL (`thomfilg`) was already correct on `main`, so no change was needed there.

> **Note:** This is a manifest-only change. The Release job's `lib/` change gate means this commit will **not** cut a new release on its own — it will be reflected on the next `lib/` release.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a manifest-only fix. Verification steps:

1. `npm pack --dry-run` — confirm no warning about bin path normalization appears in the output.
2. Inspect the generated tarball's `package.json` and confirm `bin.lint-flaky` is `bin/lint-flaky.js`.
3. `npm install -g .` locally and run `lint-flaky --help` — confirm the CLI resolves correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field `package.json` tweak with no runtime or API impact.
> 
> **Overview**
> Updates the **`lint-flaky`** CLI entry in `package.json` from `./bin/lint-flaky.js` to **`bin/lint-flaky.js`** so the manifest matches npm’s normalized form and **`npm publish`** no longer warns about bin path normalization.
> 
> This is **manifest-only**; the resolved CLI path and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11ea0478472687ac66e9974e6364345a3573296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->