### PR TITLE
feat(no-cached-api-wait): flag waits on cached GET API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Rules that frequently cause test failures in CI/CD environments.
 | [`no-immediate-assertions`](docs/rules/no-immediate-assertions.md) | Assertions immediately after state changes miss async updates                        |    ✅    | Wraps assertion in `waitFor` with appropriate timeout                                  |
 | [`no-unconditional-wait`](docs/rules/no-unconditional-wait.md)     | Fixed delays don't guarantee operations complete                                     |    ✅    | Replaces with `waitFor` condition check when assertion follows; suggests fix otherwise |
 | [`no-promise-race`](docs/rules/no-promise-race.md)                 | Promise.race can produce unpredictable test results                                  |    ❌    | No auto-fix (requires manual refactoring)                                              |
+| [`no-cached-api-wait`](docs/rules/no-cached-api-wait.md)           | Waiting on cached GET responses is an unreliable signal vs. the rendered UI          |    ❌    | No auto-fix (assert on the visible UI outcome instead)                                 |
 
 ### Medium Risk
 
@@ -405,6 +406,7 @@ The plugin uses AST (Abstract Syntax Tree) analysis to detect patterns that comm
 | `no-immediate-assertions`  |  ✅  |   ✅   |       ✅        |     ✅     |   ✅    |         ✅         |
 | `no-unconditional-wait`    |  ✅  |   ✅   |       ✅        |     ✅     |   ✅    |         ✅         |
 | `no-promise-race`          |  ✅  |   ✅   |       ✅        |     ✅     |   ✅    |         ✅         |
+| `no-cached-api-wait`       |  -   |   -    |        -        |     ✅     |   ✅    |         -          |
 | `no-index-queries`         |  -   |   -    |       ✅        |     ✅     |   ✅    |         ✅         |
 | `no-animation-wait`        |  -   |   -    |       ✅        |     ✅     |   ✅    |         -          |
 | `no-global-state-mutation` |  ✅  |   ✅   |       ✅        |     ✅     |   ✅    |         ✅         |

--- a/docs/rules/no-cached-api-wait.md
+++ b/docs/rules/no-cached-api-wait.md
@@ -20,16 +20,29 @@ The rule only runs on test files (`isTestFile(getFilename(context))`); non-test 
 
 ### What gets flagged
 
-- Bare `page.waitForResponse(...)` / `waitForResponse(...)` calls (the name is in `helperNames`), because the
-  response matcher cannot be narrowed to a non-GET method.
-- A configurable custom helper call whose options object has a `method` literal in `flagMethods` (default `GET`,
-  case-insensitive), **or** has no `method` property at all (implicit GET default).
+- **Opaque response matchers** — any call (for a name in `helperNames`) whose argument is a **predicate
+  function**, e.g. `waitForResponse(resp => resp.url().includes('/api'))`. The matcher has no method filter, so a
+  cache-served GET can satisfy it. This is detected by shape, so it also applies to custom `helperNames`.
+- The built-in `waitForResponse` / `page.waitForResponse` is additionally flagged when called with a **URL string
+  or RegExp** (e.g. `waitForResponse('/api/users')`) — also a matcher with no method filter. (This URL-string form
+  is keyed to the built-in name; see the note under [`helperNames`](#helpernames-default-waitforapiresponse-waitforresponse).)
+- A custom helper call with an **inline options object** whose `method` literal is in `flagMethods` (default
+  `GET`, case-insensitive), **or** that omits `method` entirely (implicit GET default).
+- A custom helper with the HTTP method passed **positionally** as a string literal that is in `flagMethods`
+  (e.g. `waitForApiResponse('/api/users', 'GET')`).
+
+The report message names the matched method (e.g. `GET`, or `HEAD` under a custom `flagMethods`).
 
 ### What does NOT get flagged
 
-- Waits whose `method` literal is a mutation not in `flagMethods` (`POST`/`PUT`/`DELETE`/`PATCH`).
+- Waits whose method is a mutation not in `flagMethods` (`POST`/`PUT`/`DELETE`/`PATCH`), whether the method is in
+  an options object or passed positionally.
 - A non-literal `method` value (variable or template literal) that cannot be statically determined — the rule
   stays conservative and does not flag.
+- A custom helper whose options are **not an inline object literal** — passed via a variable
+  (`waitForApiResponse(opts)`) or as only a URL string (`waitForApiResponse('/api/users')`) — because the method
+  cannot be statically inspected. (The built-in `waitForResponse` is the exception above: a bare URL-string
+  matcher is flagged since it carries no method filter.)
 
 ## Options
 
@@ -71,6 +84,12 @@ await waitForXhr({ url: "/api/users" }); // flagged
 await waitForApiResponse({ url: "/api/users" }); // allowed (not in custom list)
 ```
 
+> **Note — opaque-matcher coupling:** predicate-style matchers (a function argument) are flagged for **any** name
+> in `helperNames`. The extra URL-string matcher form (`waitForResponse('/api/users')`) is keyed specifically to
+> the built-in name `waitForResponse`. If you replace the defaults (e.g. `helperNames: ["awaitResponse"]`), a
+> predicate call like `awaitResponse(resp => …)` is still flagged, but a bare URL-string call
+> `awaitResponse('/api/users')` is treated as a custom helper (no inline options → not flagged).
+
 ## Examples
 
 ### ❌ Incorrect
@@ -98,6 +117,14 @@ await waitForApiResponse({ url: "/api/users", method: "DELETE" });
 
 // Non-literal method that can't be statically determined is left alone
 await waitForApiResponse({ url: "/api/users", method: requestMethod });
+
+// Method passed positionally as a mutation literal is allowed
+await waitForApiResponse("/api/users", "POST");
+
+// Custom helper whose options are not an inline object literal can't be
+// inspected, so the rule stays conservative and does not flag
+await waitForApiResponse(requestOptions);
+await waitForApiResponse("/api/users");
 
 // Assert on the visible UI outcome instead of the cached response
 await page.getByRole("button", { name: "Load users" }).click();

--- a/docs/rules/no-cached-api-wait.md
+++ b/docs/rules/no-cached-api-wait.md
@@ -1,0 +1,131 @@
+# no-cached-api-wait
+
+Avoid waiting on cached API/network responses; assert on the visible UI outcome instead.
+
+## Rule Details
+
+Waiting on a GET API/network response is an unreliable test signal:
+
+- A GET response can be served from the browser/HTTP cache, so the wait may resolve before (or without) a real
+  network round-trip.
+- Response-matcher predicates (e.g. `page.waitForResponse(resp => resp.url().includes('/api'))`) cannot be
+  statically narrowed to a mutating method — GET is the implicit default match.
+- A resolved response does not mean the UI has rendered the data, so the assertion that follows can still be
+  racing the DOM update.
+
+This rule flags waits on cached/GET responses and steers you toward asserting on the visible UI outcome
+(the rendered element or text) instead.
+
+The rule only runs on test files (`isTestFile(getFilename(context))`); non-test files are ignored.
+
+### What gets flagged
+
+- Bare `page.waitForResponse(...)` / `waitForResponse(...)` calls (the name is in `helperNames`), because the
+  response matcher cannot be narrowed to a non-GET method.
+- A configurable custom helper call whose options object has a `method` literal in `flagMethods` (default `GET`,
+  case-insensitive), **or** has no `method` property at all (implicit GET default).
+
+### What does NOT get flagged
+
+- Waits whose `method` literal is a mutation not in `flagMethods` (`POST`/`PUT`/`DELETE`/`PATCH`).
+- A non-literal `method` value (variable or template literal) that cannot be statically determined — the rule
+  stays conservative and does not flag.
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+```json
+{
+  "test-flakiness/no-cached-api-wait": [
+    "error",
+    {
+      "flagMethods": ["GET"],
+      "helperNames": ["waitForApiResponse", "waitForResponse"]
+    }
+  ]
+}
+```
+
+### `flagMethods` (default: `["GET"]`)
+
+The HTTP methods (case-insensitive) that should be treated as cacheable/unreliable and therefore flagged. A wait
+whose `method` literal is **not** in this list is allowed.
+
+```javascript
+// With flagMethods: ["GET", "HEAD"]
+await waitForApiResponse({ url: "/api/users", method: "HEAD" }); // flagged
+
+// With flagMethods: ["GET"] (default)
+await waitForApiResponse({ url: "/api/users", method: "HEAD" }); // allowed
+```
+
+### `helperNames` (default: `["waitForApiResponse", "waitForResponse"]`)
+
+The call names that this rule inspects. Both bare identifiers (`waitForResponse(...)`) and member calls
+(`page.waitForResponse(...)`) are matched on the terminal name.
+
+```javascript
+// With helperNames: ["waitForXhr"]
+await waitForXhr({ url: "/api/users" }); // flagged
+await waitForApiResponse({ url: "/api/users" }); // allowed (not in custom list)
+```
+
+## Examples
+
+### ❌ Incorrect
+
+```javascript
+// Bare page.waitForResponse with a URL matcher (GET is the implicit match)
+await page.waitForResponse((resp) => resp.url().includes("/api/users"));
+
+// Bare helper call
+await waitForResponse("/api/users");
+
+// Custom helper with an explicit GET method
+await waitForApiResponse({ url: "/api/users", method: "GET" });
+
+// Custom helper with no method (implicit GET default)
+await waitForApiResponse({ url: "/api/users" });
+```
+
+### ✅ Correct
+
+```javascript
+// Wait on a mutation response (not cacheable)
+await waitForApiResponse({ url: "/api/users", method: "POST" });
+await waitForApiResponse({ url: "/api/users", method: "DELETE" });
+
+// Non-literal method that can't be statically determined is left alone
+await waitForApiResponse({ url: "/api/users", method: requestMethod });
+
+// Assert on the visible UI outcome instead of the cached response
+await page.getByRole("button", { name: "Load users" }).click();
+await expect(page.getByTestId("user-list")).toBeVisible();
+```
+
+## When Not To Use It
+
+This rule may not be suitable if:
+
+- You are explicitly testing caching/network behavior and need to assert on the response itself.
+- Your GET waits are paired with a cache-busting strategy that makes them deterministic.
+
+In these cases, disable the rule inline or scope it via configuration:
+
+```javascript
+// eslint-disable-next-line test-flakiness/no-cached-api-wait
+await page.waitForResponse((resp) => resp.url().includes("/api/users"));
+```
+
+## Related Rules
+
+- [no-unconditional-wait](./no-unconditional-wait.md) - Encourages conditional waiting
+- [no-unmocked-network](./no-unmocked-network.md) - Prevents unmocked network calls
+- [no-immediate-assertions](./no-immediate-assertions.md) - Prevents timing-dependent assertions
+
+## Further Reading
+
+- [Playwright - Waiting for Elements](https://playwright.dev/docs/actionability)
+- [HTTP caching - MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching)
+- [Testing Library - Async Utilities](https://testing-library.com/docs/dom-testing-library/api-async)

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -16,6 +16,7 @@ module.exports = {
     'test-flakiness/no-global-state-mutation': 'error',
     'test-flakiness/no-test-isolation': 'error',
     'test-flakiness/no-random-data': 'error',
-    'test-flakiness/no-unmocked-network': 'error'
+    'test-flakiness/no-unmocked-network': 'error',
+    'test-flakiness/no-cached-api-wait': 'error'
   }
 };

--- a/lib/configs/strict.js
+++ b/lib/configs/strict.js
@@ -17,6 +17,7 @@ module.exports = {
     'test-flakiness/no-test-isolation': ['error', { enforceCleanup: true }],
     'test-flakiness/no-random-data': ['error', { allowSeededRandom: false }],
     'test-flakiness/no-unmocked-network': ['error', { allowLocalhost: false }],
+    'test-flakiness/no-cached-api-wait': 'error',
 
     // Medium - Additional safety rules
     'test-flakiness/no-promise-race': 'error',

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -130,31 +130,46 @@ module.exports = {
     /**
      * Decide whether a matched helper call should be reported.
      * @param {object} node The CallExpression node.
+     * @param {string} name The resolved terminal callee name.
      * @returns {boolean} True when the call waits on a flaggable (e.g. GET) response.
      */
-    function shouldFlag(node) {
+    function shouldFlag(node, name) {
       const { found, methodNode } = findMethodProperty(node);
 
-      // No options-object `method` property present. Before falling back to the
-      // implicit-GET default, check for an HTTP method passed positionally as a
-      // string literal (e.g. `waitForApiResponse('/api/users', 'POST')`); treat
-      // it as an explicit method so mutation literals are not flagged.
-      if (!found) {
-        const positional = findPositionalMethod(node);
-        if (positional.found) {
-          return flagMethods.includes(positional.method);
+      if (found) {
+        // Non-literal method (variable / template literal) is not statically
+        // determinable; stay conservative and do not flag.
+        if (methodNode.type !== 'Literal' || typeof methodNode.value !== 'string') {
+          return false;
         }
-        // Truly no static method anywhere -> implicit GET default -> flag.
+        return flagMethods.includes(methodNode.value.toLowerCase());
+      }
+
+      // No inline options-object `method` property. Check for an HTTP method
+      // passed positionally as a string literal (e.g.
+      // `waitForApiResponse('/api/users', 'POST')`); treat it as explicit.
+      const positional = findPositionalMethod(node);
+      if (positional.found) {
+        return flagMethods.includes(positional.method);
+      }
+
+      // No statically determinable method anywhere.
+      // `waitForResponse` / `page.waitForResponse` is an opaque response matcher
+      // with no method filter, so a GET can satisfy it -> flag.
+      if (name === 'waitForResponse') {
         return true;
       }
 
-      // Non-literal method (variable / template literal) is not statically
-      // determinable; stay conservative and do not flag.
-      if (methodNode.type !== 'Literal' || typeof methodNode.value !== 'string') {
-        return false;
+      // A custom helper called with an inline options object that simply omits
+      // `method` defaults to an implicit GET -> flag.
+      const hasInlineOptions = node.arguments.some(arg => arg && arg.type === 'ObjectExpression');
+      if (hasInlineOptions) {
+        return true;
       }
 
-      return flagMethods.includes(methodNode.value.toLowerCase());
+      // Otherwise the options are not statically inspectable (passed via a
+      // variable, or only a URL string) -> stay conservative and do not flag.
+      return false;
     }
 
     return {
@@ -164,7 +179,7 @@ module.exports = {
           return;
         }
 
-        if (shouldFlag(node)) {
+        if (shouldFlag(node, name)) {
           context.report({
             node,
             messageId: 'cachedApiWait'

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -99,23 +99,44 @@ module.exports = {
           continue;
         }
         if (arg.type === 'ObjectExpression') {
-          const methodProp = arg.properties.find(
-            prop =>
+          // Walk properties in source order, tracking the latest explicit
+          // `method` value and whether a spread appears AFTER it. A spread can
+          // introduce or override `method` with a value we can't read
+          // statically, so any object built with a spread that isn't provably
+          // settled by a trailing literal `method` is treated as indeterminate.
+          let methodValue = null;
+          let spreadAfterMethod = false;
+          let sawSpread = false;
+          for (const prop of arg.properties) {
+            if (prop.type === 'SpreadElement' || prop.type === 'ExperimentalSpreadProperty') {
+              sawSpread = true;
+              spreadAfterMethod = true;
+              continue;
+            }
+            const isMethodKey =
               prop.type === 'Property' &&
               // A string-literal key matches whether or not it is computed, so
               // `{ ['method']: ... }` is treated the same as `{ 'method': ... }`.
               // A computed identifier key (`{ [methodKey]: ... }`) stays excluded
               // since its resolved name is not statically known.
               ((prop.key.type === 'Literal' && prop.key.value === 'method') ||
-                (!prop.computed && prop.key.type === 'Identifier' && prop.key.name === 'method'))
-          );
-          if (methodProp) {
-            const value = methodProp.value;
-            if (value.type === 'Literal' && typeof value.value === 'string') {
-              literals.push(value.value.toLowerCase());
+                (!prop.computed && prop.key.type === 'Identifier' && prop.key.name === 'method'));
+            if (isMethodKey) {
+              methodValue = prop.value;
+              spreadAfterMethod = false;
+            }
+          }
+          if (methodValue && !spreadAfterMethod) {
+            // An explicit `method` that no later spread can override.
+            if (methodValue.type === 'Literal' && typeof methodValue.value === 'string') {
+              literals.push(methodValue.value.toLowerCase());
             } else {
               hasNonLiteral = true;
             }
+          } else if (methodValue || sawSpread) {
+            // Either a non-literal/overridable method, or a spread that may carry
+            // a `method` we can't see -> not statically determinable.
+            hasNonLiteral = true;
           }
         } else if (
           // The FIRST argument is the URL / RegExp / predicate matcher, never a

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -164,6 +164,14 @@ module.exports = {
         return flagMethods.includes(positional.method) ? positional.method.toUpperCase() : null;
       }
 
+      // Every remaining branch represents an IMPLICIT GET (an opaque matcher, a
+      // bare URL matcher, or an inline options object that omits `method`).
+      // Honor `flagMethods`: when GET is excluded from it, none of these
+      // implicit-GET waits should be flagged.
+      if (!flagMethods.includes('get')) {
+        return null;
+      }
+
       // No statically determinable method anywhere. An opaque response matcher
       // — a call whose argument is a predicate function (e.g.
       // `waitForResponse(resp => resp.url().includes('/api'))`) — has no method

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -93,9 +93,12 @@ module.exports = {
       const methodProp = objectArg.properties.find(
         prop =>
           prop.type === 'Property' &&
-          !prop.computed &&
-          ((prop.key.type === 'Identifier' && prop.key.name === 'method') ||
-            (prop.key.type === 'Literal' && prop.key.value === 'method'))
+          // A string-literal key matches whether or not it is computed, so
+          // `{ ['method']: ... }` is treated the same as `{ 'method': ... }`.
+          // A computed identifier key (`{ [methodKey]: ... }`) stays excluded
+          // since its resolved name is not statically known.
+          ((prop.key.type === 'Literal' && prop.key.value === 'method') ||
+            (!prop.computed && prop.key.type === 'Identifier' && prop.key.name === 'method'))
       );
       if (!methodProp) {
         return { found: false, methodNode: null };

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -1,0 +1,135 @@
+/**
+ * @fileoverview Rule to avoid asserting on cached API responses instead of the visible UI outcome
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const { isTestFile, getFilename } = require('../utils/helpers');
+
+const DEFAULT_FLAG_METHODS = ['GET'];
+const DEFAULT_HELPER_NAMES = ['waitForApiResponse', 'waitForResponse'];
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Avoid waiting on cached API/network responses; assert on the visible UI outcome instead',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/tigredonorte/eslint-plugin-test-flakiness/blob/main/docs/rules/no-cached-api-wait.md'
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          flagMethods: {
+            type: 'array',
+            items: { type: 'string' },
+            default: DEFAULT_FLAG_METHODS
+          },
+          helperNames: {
+            type: 'array',
+            items: { type: 'string' },
+            default: DEFAULT_HELPER_NAMES
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      cachedApiWait:
+        'Avoid waiting on the cached API response; a GET response can be served from cache and is not a reliable signal. Assert on the visible UI outcome (e.g. the rendered element/text) instead.'
+    }
+  },
+
+  create(context) {
+    if (!isTestFile(getFilename(context))) {
+      return {};
+    }
+
+    const options = context.options[0] || {};
+    const flagMethods = (options.flagMethods || DEFAULT_FLAG_METHODS).map(m =>
+      String(m).toLowerCase()
+    );
+    const helperNames = options.helperNames || DEFAULT_HELPER_NAMES;
+
+    /**
+     * Resolve the terminal callee name for a CallExpression.
+     * Handles both `helper(...)` (Identifier) and `page.helper(...)` (MemberExpression).
+     * @param {object} callee The callee node.
+     * @returns {string|null} The terminal name, or null when not statically known.
+     */
+    function getCalleeName(callee) {
+      if (callee.type === 'Identifier') {
+        return callee.name;
+      }
+      if (callee.type === 'MemberExpression' && callee.property.type === 'Identifier') {
+        return callee.property.name;
+      }
+      return null;
+    }
+
+    /**
+     * Find the `method` property value from an options-object argument.
+     * @param {object} node The CallExpression node.
+     * @returns {{found: boolean, methodNode: (object|null)}} Lookup result.
+     */
+    function findMethodProperty(node) {
+      const objectArg = node.arguments.find(arg => arg && arg.type === 'ObjectExpression');
+      if (!objectArg) {
+        return { found: false, methodNode: null };
+      }
+      const methodProp = objectArg.properties.find(
+        prop =>
+          prop.type === 'Property' &&
+          !prop.computed &&
+          ((prop.key.type === 'Identifier' && prop.key.name === 'method') ||
+            (prop.key.type === 'Literal' && prop.key.value === 'method'))
+      );
+      if (!methodProp) {
+        return { found: false, methodNode: null };
+      }
+      return { found: true, methodNode: methodProp.value };
+    }
+
+    /**
+     * Decide whether a matched helper call should be reported.
+     * @param {object} node The CallExpression node.
+     * @returns {boolean} True when the call waits on a flaggable (e.g. GET) response.
+     */
+    function shouldFlag(node) {
+      const { found, methodNode } = findMethodProperty(node);
+
+      // No method property present -> implicit GET default -> flag.
+      if (!found) {
+        return true;
+      }
+
+      // Non-literal method (variable / template literal) is not statically
+      // determinable; stay conservative and do not flag.
+      if (methodNode.type !== 'Literal' || typeof methodNode.value !== 'string') {
+        return false;
+      }
+
+      return flagMethods.includes(methodNode.value.toLowerCase());
+    }
+
+    return {
+      CallExpression(node) {
+        const name = getCalleeName(node.callee);
+        if (!name || !helperNames.includes(name)) {
+          return;
+        }
+
+        if (shouldFlag(node)) {
+          context.report({
+            node,
+            messageId: 'cachedApiWait'
+          });
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -86,24 +86,30 @@ module.exports = {
      * @returns {{found: boolean, methodNode: (object|null)}} Lookup result.
      */
     function findMethodProperty(node) {
-      const objectArg = node.arguments.find(arg => arg && arg.type === 'ObjectExpression');
-      if (!objectArg) {
-        return { found: false, methodNode: null };
+      // Scan EVERY inline object argument, not just the first: a helper may take
+      // the options (carrying `method`) as a later positional argument
+      // (e.g. `waitForApiResponse('/api', { headers }, { method: 'POST' })`).
+      // Reading only the first object would miss the method and mis-classify the
+      // mutation wait as an implicit GET.
+      for (const arg of node.arguments) {
+        if (!arg || arg.type !== 'ObjectExpression') {
+          continue;
+        }
+        const methodProp = arg.properties.find(
+          prop =>
+            prop.type === 'Property' &&
+            // A string-literal key matches whether or not it is computed, so
+            // `{ ['method']: ... }` is treated the same as `{ 'method': ... }`.
+            // A computed identifier key (`{ [methodKey]: ... }`) stays excluded
+            // since its resolved name is not statically known.
+            ((prop.key.type === 'Literal' && prop.key.value === 'method') ||
+              (!prop.computed && prop.key.type === 'Identifier' && prop.key.name === 'method'))
+        );
+        if (methodProp) {
+          return { found: true, methodNode: methodProp.value };
+        }
       }
-      const methodProp = objectArg.properties.find(
-        prop =>
-          prop.type === 'Property' &&
-          // A string-literal key matches whether or not it is computed, so
-          // `{ ['method']: ... }` is treated the same as `{ 'method': ... }`.
-          // A computed identifier key (`{ [methodKey]: ... }`) stays excluded
-          // since its resolved name is not statically known.
-          ((prop.key.type === 'Literal' && prop.key.value === 'method') ||
-            (!prop.computed && prop.key.type === 'Identifier' && prop.key.name === 'method'))
-      );
-      if (!methodProp) {
-        return { found: false, methodNode: null };
-      }
-      return { found: true, methodNode: methodProp.value };
+      return { found: false, methodNode: null };
     }
 
     /**

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -49,7 +49,7 @@ module.exports = {
     ],
     messages: {
       cachedApiWait:
-        'Avoid waiting on the cached API response; a GET response can be served from cache and is not a reliable signal. Assert on the visible UI outcome (e.g. the rendered element/text) instead.'
+        'Avoid waiting on the cached API response; a {{method}} response can be served from cache and is not a reliable signal. Assert on the visible UI outcome (e.g. the rendered element/text) instead.'
     }
   },
 
@@ -128,21 +128,26 @@ module.exports = {
     }
 
     /**
-     * Decide whether a matched helper call should be reported.
+     * Determine the effective HTTP method a matched helper call waits on, when
+     * that method is one the rule should flag. Returns the upper-cased method
+     * string to report (e.g. `'GET'`, `'HEAD'`), or `null` when the call should
+     * not be flagged. The returned method is interpolated into the report
+     * message so it stays accurate under a custom `flagMethods`.
      * @param {object} node The CallExpression node.
      * @param {string} name The resolved terminal callee name.
-     * @returns {boolean} True when the call waits on a flaggable (e.g. GET) response.
+     * @returns {string|null} The flaggable method, or null to skip.
      */
-    function shouldFlag(node, name) {
+    function matchedMethod(node, name) {
       const { found, methodNode } = findMethodProperty(node);
 
       if (found) {
         // Non-literal method (variable / template literal) is not statically
         // determinable; stay conservative and do not flag.
         if (methodNode.type !== 'Literal' || typeof methodNode.value !== 'string') {
-          return false;
+          return null;
         }
-        return flagMethods.includes(methodNode.value.toLowerCase());
+        const method = methodNode.value.toLowerCase();
+        return flagMethods.includes(method) ? method.toUpperCase() : null;
       }
 
       // No inline options-object `method` property. Check for an HTTP method
@@ -150,26 +155,42 @@ module.exports = {
       // `waitForApiResponse('/api/users', 'POST')`); treat it as explicit.
       const positional = findPositionalMethod(node);
       if (positional.found) {
-        return flagMethods.includes(positional.method);
+        return flagMethods.includes(positional.method) ? positional.method.toUpperCase() : null;
       }
 
-      // No statically determinable method anywhere.
-      // `waitForResponse` / `page.waitForResponse` is an opaque response matcher
-      // with no method filter, so a GET can satisfy it -> flag.
+      // No statically determinable method anywhere. An opaque response matcher
+      // — a call whose argument is a predicate function (e.g.
+      // `waitForResponse(resp => resp.url().includes('/api'))`) — has no method
+      // filter, so a cache-served GET can satisfy it. This is detected by shape
+      // (predicate arg), so it applies to custom `helperNames` too.
+      const hasPredicateArg = node.arguments.some(
+        arg =>
+          arg &&
+          (arg.type === 'ArrowFunctionExpression' || arg.type === 'FunctionExpression')
+      );
+      if (hasPredicateArg) {
+        return 'GET';
+      }
+
+      // The built-in `waitForResponse` / `page.waitForResponse` matcher also
+      // accepts a URL string/RegExp with no method filter. NOTE: this URL-string
+      // form is keyed to the built-in name; a consumer who renames it via
+      // `helperNames` gets only the predicate/options detection above. See the
+      // rule docs ("opaque matcher") for this coupling.
       if (name === 'waitForResponse') {
-        return true;
+        return 'GET';
       }
 
       // A custom helper called with an inline options object that simply omits
       // `method` defaults to an implicit GET -> flag.
       const hasInlineOptions = node.arguments.some(arg => arg && arg.type === 'ObjectExpression');
       if (hasInlineOptions) {
-        return true;
+        return 'GET';
       }
 
       // Otherwise the options are not statically inspectable (passed via a
       // variable, or only a URL string) -> stay conservative and do not flag.
-      return false;
+      return null;
     }
 
     return {
@@ -179,10 +200,12 @@ module.exports = {
           return;
         }
 
-        if (shouldFlag(node, name)) {
+        const method = matchedMethod(node, name);
+        if (method) {
           context.report({
             node,
-            messageId: 'cachedApiWait'
+            messageId: 'cachedApiWait',
+            data: { method }
           });
         }
       }

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -81,56 +81,50 @@ module.exports = {
     }
 
     /**
-     * Find the `method` property value from an options-object argument.
+     * Collect every statically-known HTTP-method signal from a call's
+     * arguments: a `method` property on ANY inline options object, plus any
+     * positional method-string literal. Order-independent, so a method hint in
+     * a later argument can't be hidden by an earlier one.
      * @param {object} node The CallExpression node.
-     * @returns {{found: boolean, methodNode: (object|null)}} Lookup result.
+     * @returns {{literals: string[], hasNonLiteral: boolean}} Lowercased method
+     *   literals found across all arguments, and whether any `method` value was
+     *   a non-literal (variable / template) that can't be read statically.
      */
-    function findMethodProperty(node) {
-      // Scan EVERY inline object argument, not just the first: a helper may take
-      // the options (carrying `method`) as a later positional argument
-      // (e.g. `waitForApiResponse('/api', { headers }, { method: 'POST' })`).
-      // Reading only the first object would miss the method and mis-classify the
-      // mutation wait as an implicit GET.
+    function collectMethodSignals(node) {
+      const literals = [];
+      let hasNonLiteral = false;
       for (const arg of node.arguments) {
-        if (!arg || arg.type !== 'ObjectExpression') {
+        if (!arg) {
           continue;
         }
-        const methodProp = arg.properties.find(
-          prop =>
-            prop.type === 'Property' &&
-            // A string-literal key matches whether or not it is computed, so
-            // `{ ['method']: ... }` is treated the same as `{ 'method': ... }`.
-            // A computed identifier key (`{ [methodKey]: ... }`) stays excluded
-            // since its resolved name is not statically known.
-            ((prop.key.type === 'Literal' && prop.key.value === 'method') ||
-              (!prop.computed && prop.key.type === 'Identifier' && prop.key.name === 'method'))
-        );
-        if (methodProp) {
-          return { found: true, methodNode: methodProp.value };
-        }
-      }
-      return { found: false, methodNode: null };
-    }
-
-    /**
-     * Find an HTTP method passed as a positional string-literal argument, used
-     * when no options-object `method` property is present (e.g.
-     * `waitForApiResponse('/api/users', 'POST')`).
-     * @param {object} node The CallExpression node.
-     * @returns {{found: boolean, method: (string|null)}} Lookup result.
-     */
-    function findPositionalMethod(node) {
-      const methodArg = node.arguments.find(
-        arg =>
-          arg &&
+        if (arg.type === 'ObjectExpression') {
+          const methodProp = arg.properties.find(
+            prop =>
+              prop.type === 'Property' &&
+              // A string-literal key matches whether or not it is computed, so
+              // `{ ['method']: ... }` is treated the same as `{ 'method': ... }`.
+              // A computed identifier key (`{ [methodKey]: ... }`) stays excluded
+              // since its resolved name is not statically known.
+              ((prop.key.type === 'Literal' && prop.key.value === 'method') ||
+                (!prop.computed && prop.key.type === 'Identifier' && prop.key.name === 'method'))
+          );
+          if (methodProp) {
+            const value = methodProp.value;
+            if (value.type === 'Literal' && typeof value.value === 'string') {
+              literals.push(value.value.toLowerCase());
+            } else {
+              hasNonLiteral = true;
+            }
+          }
+        } else if (
           arg.type === 'Literal' &&
           typeof arg.value === 'string' &&
           KNOWN_HTTP_METHODS.has(arg.value.toLowerCase())
-      );
-      if (!methodArg) {
-        return { found: false, method: null };
+        ) {
+          literals.push(arg.value.toLowerCase());
+        }
       }
-      return { found: true, method: methodArg.value.toLowerCase() };
+      return { literals, hasNonLiteral };
     }
 
     /**
@@ -144,30 +138,31 @@ module.exports = {
      * @returns {string|null} The flaggable method, or null to skip.
      */
     function matchedMethod(node, name) {
-      const { found, methodNode } = findMethodProperty(node);
+      const { literals, hasNonLiteral } = collectMethodSignals(node);
 
-      if (found) {
-        // Non-literal method (variable / template literal) is not statically
-        // determinable; stay conservative and do not flag.
-        if (methodNode.type !== 'Literal' || typeof methodNode.value !== 'string') {
-          return null;
-        }
-        const method = methodNode.value.toLowerCase();
-        return flagMethods.includes(method) ? method.toUpperCase() : null;
+      // An explicit mutation literal anywhere (a method NOT in `flagMethods`)
+      // means a real network request fires, so the wait is reliable — never
+      // flag, even if another argument also carries a flaggable literal.
+      if (literals.some(method => !flagMethods.includes(method))) {
+        return null;
       }
 
-      // No inline options-object `method` property. Check for an HTTP method
-      // passed positionally as a string literal (e.g.
-      // `waitForApiResponse('/api/users', 'POST')`); treat it as explicit.
-      const positional = findPositionalMethod(node);
-      if (positional.found) {
-        return flagMethods.includes(positional.method) ? positional.method.toUpperCase() : null;
+      // Any explicit flaggable literal (e.g. GET) — report it.
+      const flaggable = literals.find(method => flagMethods.includes(method));
+      if (flaggable) {
+        return flaggable.toUpperCase();
       }
 
-      // Every remaining branch represents an IMPLICIT GET (an opaque matcher, a
-      // bare URL matcher, or an inline options object that omits `method`).
-      // Honor `flagMethods`: when GET is excluded from it, none of these
-      // implicit-GET waits should be flagged.
+      // A `method` we couldn't read statically (variable / template literal) is
+      // not determinable; stay conservative and do not flag.
+      if (hasNonLiteral) {
+        return null;
+      }
+
+      // No explicit method anywhere. Every remaining branch represents an
+      // IMPLICIT GET (an opaque matcher, a bare URL matcher, or an inline
+      // options object that omits `method`). Honor `flagMethods`: when GET is
+      // excluded from it, none of these implicit-GET waits should be flagged.
       if (!flagMethods.includes('get')) {
         return null;
       }

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -93,7 +93,8 @@ module.exports = {
     function collectMethodSignals(node) {
       const literals = [];
       let hasNonLiteral = false;
-      for (const arg of node.arguments) {
+      for (let index = 0; index < node.arguments.length; index += 1) {
+        const arg = node.arguments[index];
         if (!arg) {
           continue;
         }
@@ -117,6 +118,11 @@ module.exports = {
             }
           }
         } else if (
+          // The FIRST argument is the URL / RegExp / predicate matcher, never a
+          // method — so a method-looking first arg (e.g. `waitForResponse('POST')`)
+          // must not suppress reporting. Only later positional string literals
+          // count as method hints.
+          index > 0 &&
           arg.type === 'Literal' &&
           typeof arg.value === 'string' &&
           KNOWN_HTTP_METHODS.has(arg.value.toLowerCase())

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -180,16 +180,10 @@ module.exports = {
         return flaggable.toUpperCase();
       }
 
-      // A `method` we couldn't read statically (variable / template literal) is
-      // not determinable; stay conservative and do not flag.
-      if (hasNonLiteral) {
-        return null;
-      }
-
-      // No explicit method anywhere. Every remaining branch represents an
-      // IMPLICIT GET (an opaque matcher, a bare URL matcher, or an inline
-      // options object that omits `method`). Honor `flagMethods`: when GET is
-      // excluded from it, none of these implicit-GET waits should be flagged.
+      // No explicit flaggable method literal. Every remaining flag path is an
+      // IMPLICIT GET (an opaque predicate matcher, a bare URL matcher, or an
+      // inline options object that omits `method`). Honor `flagMethods`: when
+      // GET is excluded from it, none of these implicit-GET waits are flagged.
       if (!flagMethods.includes('get')) {
         return null;
       }
@@ -206,6 +200,13 @@ module.exports = {
       );
       if (hasPredicateArg) {
         return 'GET';
+      }
+
+      // No opaque predicate matcher above. If a `method` exists but couldn't be
+      // read statically (variable / template / spread-built), it's not
+      // determinable -> stay conservative and do not flag.
+      if (hasNonLiteral) {
+        return null;
       }
 
       // The built-in `waitForResponse` / `page.waitForResponse` matcher also

--- a/lib/rules/no-cached-api-wait.js
+++ b/lib/rules/no-cached-api-wait.js
@@ -8,6 +8,15 @@ const { isTestFile, getFilename } = require('../utils/helpers');
 
 const DEFAULT_FLAG_METHODS = ['GET'];
 const DEFAULT_HELPER_NAMES = ['waitForApiResponse', 'waitForResponse'];
+const KNOWN_HTTP_METHODS = new Set([
+  'get',
+  'post',
+  'put',
+  'delete',
+  'patch',
+  'head',
+  'options'
+]);
 
 module.exports = {
   meta: {
@@ -95,6 +104,27 @@ module.exports = {
     }
 
     /**
+     * Find an HTTP method passed as a positional string-literal argument, used
+     * when no options-object `method` property is present (e.g.
+     * `waitForApiResponse('/api/users', 'POST')`).
+     * @param {object} node The CallExpression node.
+     * @returns {{found: boolean, method: (string|null)}} Lookup result.
+     */
+    function findPositionalMethod(node) {
+      const methodArg = node.arguments.find(
+        arg =>
+          arg &&
+          arg.type === 'Literal' &&
+          typeof arg.value === 'string' &&
+          KNOWN_HTTP_METHODS.has(arg.value.toLowerCase())
+      );
+      if (!methodArg) {
+        return { found: false, method: null };
+      }
+      return { found: true, method: methodArg.value.toLowerCase() };
+    }
+
+    /**
      * Decide whether a matched helper call should be reported.
      * @param {object} node The CallExpression node.
      * @returns {boolean} True when the call waits on a flaggable (e.g. GET) response.
@@ -102,8 +132,16 @@ module.exports = {
     function shouldFlag(node) {
       const { found, methodNode } = findMethodProperty(node);
 
-      // No method property present -> implicit GET default -> flag.
+      // No options-object `method` property present. Before falling back to the
+      // implicit-GET default, check for an HTTP method passed positionally as a
+      // string literal (e.g. `waitForApiResponse('/api/users', 'POST')`); treat
+      // it as an explicit method so mutation literals are not flagged.
       if (!found) {
+        const positional = findPositionalMethod(node);
+        if (positional.found) {
+          return flagMethods.includes(positional.method);
+        }
+        // Truly no static method anywhere -> implicit GET default -> flag.
         return true;
       }
 

--- a/tests/lib/configs/no-cached-api-wait-registration.test.js
+++ b/tests/lib/configs/no-cached-api-wait-registration.test.js
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview Verifies `no-cached-api-wait` is registered in the recommended
+ * and strict configs at 'error' severity (GH-49 Task 2).
+ */
+'use strict';
+
+const recommended = require('../../../lib/configs/recommended');
+const strict = require('../../../lib/configs/strict');
+
+const RULE = 'test-flakiness/no-cached-api-wait';
+
+describe('no-cached-api-wait config registration', () => {
+  it('registers the rule in the recommended config at error severity', () => {
+    expect(recommended.rules).toBeDefined();
+    expect(recommended.rules[RULE]).toBe('error');
+  });
+
+  it('registers the rule in the strict config at error severity', () => {
+    expect(strict.rules).toBeDefined();
+    const entry = strict.rules[RULE];
+    const severity = Array.isArray(entry) ? entry[0] : entry;
+    expect(severity).toBe('error');
+  });
+});

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -106,6 +106,13 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js',
       options: [{ flagMethods: ['POST'] }]
     },
+    // 1.3 — The built-in `waitForResponse` URL-string matcher is also an implicit
+    // GET, so it too is suppressed when flagMethods excludes GET.
+    {
+      code: 'await waitForResponse(\'/api/users\')',
+      filename: 'users.test.js',
+      options: [{ flagMethods: ['POST'] }]
+    },
 
     // 1.4 — Recommended UI-assertion good pattern (no API wait at all)
     {

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -68,6 +68,13 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js'
     },
 
+    // 1.3 — Computed string-literal `method` key is honored like a normal key;
+    // a mutation literal is not flagged.
+    {
+      code: 'await waitForApiResponse({ [\'method\']: \'POST\', url: \'/api\' })',
+      filename: 'users.test.js'
+    },
+
     // 1.4 — Recommended UI-assertion good pattern (no API wait at all)
     {
       code: 'await page.getByTestId(\'submit\').click(); await page.getByTestId(\'result\').isVisible()',
@@ -124,6 +131,12 @@ ruleTester.run('no-cached-api-wait', rule, {
     // 1.3 — No method anywhere (implicit GET default) still flags
     {
       code: 'await waitForApiResponse(\'/api/users\')',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+    // 1.3 — Computed string-literal `method` key with a GET literal still flags
+    {
+      code: 'await waitForApiResponse({ [\'method\']: \'GET\', url: \'/api\' })',
       filename: 'users.test.js',
       errors: [{ messageId: 'cachedApiWait' }]
     },

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview Tests for no-cached-api-wait rule
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/no-cached-api-wait');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
+
+const ruleTester = getRuleTester();
+
+// RuleTester.run() registers its own it() blocks, so it must run at module
+// scope (not nested inside another it()). The cases below stand in for the
+// per-scenario it()/test() blocks for this rule's suite.
+ruleTester.run('no-cached-api-wait', rule, {
+  valid: [
+    // 1.1 — Non-test files are ignored even with a flaggable GET helper
+    {
+      code: 'waitForApiResponse({ method: \'GET\' })',
+      filename: 'src/app.js'
+    },
+
+    // 1.3 — Mutation method literals are not flagged (POST/PUT/DELETE/PATCH)
+    {
+      code: 'await waitForApiResponse({ method: \'POST\', url: \'/api/users\' })',
+      filename: 'users.test.js'
+    },
+    {
+      code: 'await waitForApiResponse({ method: \'PUT\', url: \'/api/users/1\' })',
+      filename: 'users.test.js'
+    },
+    {
+      code: 'await waitForApiResponse({ method: \'DELETE\', url: \'/api/users/1\' })',
+      filename: 'users.test.js'
+    },
+    {
+      code: 'await waitForApiResponse({ method: \'PATCH\', url: \'/api/users/1\' })',
+      filename: 'users.test.js'
+    },
+
+    // 1.3 — Non-literal method (variable) is not statically determinable -> skip
+    {
+      code: 'await waitForApiResponse({ method: someMethod, url: \'/api\' })',
+      filename: 'flow.test.js'
+    },
+    // 1.3 — Non-literal method (template literal) -> skip
+    {
+      code: 'await waitForApiResponse({ method: `${verb}`, url: "/api" })',
+      filename: 'flow.test.js'
+    },
+
+    // 1.4 — Recommended UI-assertion good pattern (no API wait at all)
+    {
+      code: 'await page.getByTestId(\'submit\').click(); await page.getByTestId(\'result\').isVisible()',
+      filename: 'flow.test.js'
+    },
+
+    // 1.4 — With a custom helperNames option, the default helper is NOT flagged
+    {
+      code: 'await waitForApiResponse({ method: \'GET\' })',
+      filename: 'flow.test.js',
+      options: [{ helperNames: ['waitForXhr'] }]
+    }
+  ],
+
+  invalid: [
+    // 1.2 — Bare page.waitForResponse with a URL matcher predicate (implicit GET)
+    {
+      code: 'await page.waitForResponse(resp => resp.url().includes(\'/api\'))',
+      filename: 'page.test.js',
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+    // 1.2 — Bare waitForResponse identifier call
+    {
+      code: 'await waitForResponse(resp => resp.url().includes(\'/api\'))',
+      filename: 'page.test.js',
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+
+    // 1.3 — Custom helper with explicit GET method (case-insensitive)
+    {
+      code: 'await waitForApiResponse({ method: \'GET\', url: \'/api/users\' })',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+    {
+      code: 'await waitForApiResponse({ method: \'get\', url: \'/api/users\' })',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+
+    // 1.3 — Custom helper with NO method property (implicit GET default)
+    {
+      code: 'await waitForApiResponse({ url: \'/api/users\' })',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+
+    // 1.4 — Custom helperNames option flags the configured helper name
+    {
+      code: 'await waitForXhr({ method: \'GET\', url: \'/api\' })',
+      filename: 'flow.test.js',
+      options: [{ helperNames: ['waitForXhr'] }],
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+
+    // 1.4 — Custom flagMethods option flags HEAD (in addition to GET)
+    {
+      code: 'await waitForApiResponse({ method: \'HEAD\', url: \'/api\' })',
+      filename: 'flow.test.js',
+      options: [{ flagMethods: ['GET', 'HEAD'] }],
+      errors: [{ messageId: 'cachedApiWait' }]
+    }
+  ]
+});

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -93,6 +93,19 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js'
     },
 
+    // 1.3 — A mutation literal anywhere wins: an earlier flaggable GET literal
+    // does not hide a later POST in another argument.
+    {
+      code: 'await waitForApiResponse({ method: \'GET\' }, { method: \'POST\' })',
+      filename: 'users.test.js'
+    },
+    // 1.3 — A positional mutation literal is honored even alongside a
+    // non-literal options `method` (which on its own would be skipped).
+    {
+      code: 'await waitForApiResponse({ method: dynamicMethod }, \'POST\')',
+      filename: 'users.test.js'
+    },
+
     // 1.3 — Implicit-GET waits honor flagMethods: when GET is excluded, neither
     // an opaque predicate matcher nor an inline options object without `method`
     // is flagged.

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -193,6 +193,13 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js',
       errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
     },
+    // 1.3 — A method-looking FIRST argument is the matcher, not a method hint:
+    // `waitForResponse('POST')` is still an unfiltered matcher -> flagged as GET.
+    {
+      code: 'await waitForResponse(\'POST\')',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
+    },
 
     // 1.4 — Custom helperNames option flags the configured helper name
     {

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -200,6 +200,13 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js',
       errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
     },
+    // 1.3 — Default config flags the built-in `waitForResponse` URL-string
+    // matcher form (exercises the `name === 'waitForResponse'` branch).
+    {
+      code: 'await waitForResponse(\'/api/users\')',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
+    },
 
     // 1.4 — Custom helperNames option flags the configured helper name
     {

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -106,6 +106,19 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js'
     },
 
+    // 1.3 — A spread-built options object may carry `method` we can't read
+    // statically, so stay conservative and do NOT flag.
+    {
+      code: 'await waitForApiResponse({ ...options, url: \'/api\' })',
+      filename: 'users.test.js'
+    },
+    // 1.3 — A trailing spread can override an earlier explicit method, so it is
+    // also indeterminate.
+    {
+      code: 'await waitForApiResponse({ method: \'GET\', ...options })',
+      filename: 'users.test.js'
+    },
+
     // 1.3 — Implicit-GET waits honor flagMethods: when GET is excluded, neither
     // an opaque predicate matcher nor an inline options object without `method`
     // is flagged.
@@ -204,6 +217,12 @@ ruleTester.run('no-cached-api-wait', rule, {
     // matcher form (exercises the `name === 'waitForResponse'` branch).
     {
       code: 'await waitForResponse(\'/api/users\')',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
+    },
+    // 1.3 — An explicit GET `method` AFTER a spread provably wins -> flagged.
+    {
+      code: 'await waitForApiResponse({ ...options, method: \'GET\' })',
       filename: 'users.test.js',
       errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
     },

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -130,7 +130,8 @@ ruleTester.run('no-cached-api-wait', rule, {
     {
       code: 'await waitForApiResponse({ url: \'/api/users\' })',
       filename: 'users.test.js',
-      errors: [{ messageId: 'cachedApiWait' }]
+      // Message interpolates the matched method (implicit GET here).
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
     },
 
     // 1.3 — Positional GET literal arg is treated as explicit flaggable method
@@ -154,12 +155,22 @@ ruleTester.run('no-cached-api-wait', rule, {
       errors: [{ messageId: 'cachedApiWait' }]
     },
 
-    // 1.4 — Custom flagMethods option flags HEAD (in addition to GET)
+    // 1.4 — Custom flagMethods option flags HEAD (in addition to GET); the
+    // message reflects the matched method rather than a hardcoded "GET".
     {
       code: 'await waitForApiResponse({ method: \'HEAD\', url: \'/api\' })',
       filename: 'flow.test.js',
       options: [{ flagMethods: ['GET', 'HEAD'] }],
-      errors: [{ messageId: 'cachedApiWait' }]
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'HEAD' } }]
+    },
+
+    // 1.4 — Opaque matcher detection is shape-based (predicate arg), so a custom
+    // helper name that replaces the defaults still flags a bare predicate wait.
+    {
+      code: 'await awaitResponse(resp => resp.url().includes(\'/api\'))',
+      filename: 'flow.test.js',
+      options: [{ helperNames: ['awaitResponse'] }],
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
     }
   ]
 });

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -86,6 +86,13 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js'
     },
 
+    // 1.3 — `method` may live in a LATER object argument; a mutation there must
+    // still be honored (not mis-read as implicit GET from an earlier object).
+    {
+      code: 'await waitForApiResponse(\'/api\', { retries: 3 }, { method: \'POST\' })',
+      filename: 'users.test.js'
+    },
+
     // 1.4 — Recommended UI-assertion good pattern (no API wait at all)
     {
       code: 'await page.getByTestId(\'submit\').click(); await page.getByTestId(\'result\').isVisible()',
@@ -145,6 +152,12 @@ ruleTester.run('no-cached-api-wait', rule, {
       code: 'await waitForApiResponse({ [\'method\']: \'GET\', url: \'/api\' })',
       filename: 'users.test.js',
       errors: [{ messageId: 'cachedApiWait' }]
+    },
+    // 1.3 — A GET `method` in a LATER object argument is still detected
+    {
+      code: 'await waitForApiResponse(\'/api\', { retries: 3 }, { method: \'GET\' })',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
     },
 
     // 1.4 — Custom helperNames option flags the configured helper name

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -49,6 +49,25 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'flow.test.js'
     },
 
+    // 1.3 — Positional HTTP-method literal arg is treated as explicit method;
+    // mutation literals (POST/PUT/DELETE/PATCH) are not flagged.
+    {
+      code: 'await waitForApiResponse(\'/api/users\', \'POST\')',
+      filename: 'users.test.js'
+    },
+    {
+      code: 'await waitForApiResponse(\'/api/users\', \'PUT\')',
+      filename: 'users.test.js'
+    },
+    {
+      code: 'await waitForApiResponse(\'/api/users\', \'DELETE\')',
+      filename: 'users.test.js'
+    },
+    {
+      code: 'await waitForApiResponse(\'/api/users\', \'PATCH\')',
+      filename: 'users.test.js'
+    },
+
     // 1.4 — Recommended UI-assertion good pattern (no API wait at all)
     {
       code: 'await page.getByTestId(\'submit\').click(); await page.getByTestId(\'result\').isVisible()',
@@ -92,6 +111,19 @@ ruleTester.run('no-cached-api-wait', rule, {
     // 1.3 — Custom helper with NO method property (implicit GET default)
     {
       code: 'await waitForApiResponse({ url: \'/api/users\' })',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+
+    // 1.3 — Positional GET literal arg is treated as explicit flaggable method
+    {
+      code: 'await waitForApiResponse(\'/api/users\', \'GET\')',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait' }]
+    },
+    // 1.3 — No method anywhere (implicit GET default) still flags
+    {
+      code: 'await waitForApiResponse(\'/api/users\')',
       filename: 'users.test.js',
       errors: [{ messageId: 'cachedApiWait' }]
     },

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -226,6 +226,18 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js',
       errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
     },
+    // 1.3 — An opaque predicate matcher is flagged even when another argument
+    // carries an indeterminate method (spread-built or non-literal).
+    {
+      code: 'await waitForApiResponse(resp => resp.url().includes(\'/api\'), { ...options })',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
+    },
+    {
+      code: 'await waitForApiResponse({ method: dynamicMethod }, resp => resp.url().includes(\'/api\'))',
+      filename: 'users.test.js',
+      errors: [{ messageId: 'cachedApiWait', data: { method: 'GET' } }]
+    },
 
     // 1.4 — Custom helperNames option flags the configured helper name
     {

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -93,6 +93,20 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js'
     },
 
+    // 1.3 — Implicit-GET waits honor flagMethods: when GET is excluded, neither
+    // an opaque predicate matcher nor an inline options object without `method`
+    // is flagged.
+    {
+      code: 'await waitForResponse(resp => resp.url().includes(\'/api\'))',
+      filename: 'users.test.js',
+      options: [{ flagMethods: ['POST'] }]
+    },
+    {
+      code: 'await waitForApiResponse({ url: \'/api\' })',
+      filename: 'users.test.js',
+      options: [{ flagMethods: ['POST'] }]
+    },
+
     // 1.4 — Recommended UI-assertion good pattern (no API wait at all)
     {
       code: 'await page.getByTestId(\'submit\').click(); await page.getByTestId(\'result\').isVisible()',

--- a/tests/lib/rules/no-cached-api-wait.test.js
+++ b/tests/lib/rules/no-cached-api-wait.test.js
@@ -75,6 +75,17 @@ ruleTester.run('no-cached-api-wait', rule, {
       filename: 'users.test.js'
     },
 
+    // 1.3 — Custom helper whose options are not an inline object literal cannot
+    // be statically inspected; stay conservative and do NOT flag.
+    {
+      code: 'await waitForApiResponse(opts)',
+      filename: 'users.test.js'
+    },
+    {
+      code: 'await waitForApiResponse(\'/api/users\')',
+      filename: 'users.test.js'
+    },
+
     // 1.4 — Recommended UI-assertion good pattern (no API wait at all)
     {
       code: 'await page.getByTestId(\'submit\').click(); await page.getByTestId(\'result\').isVisible()',
@@ -125,12 +136,6 @@ ruleTester.run('no-cached-api-wait', rule, {
     // 1.3 — Positional GET literal arg is treated as explicit flaggable method
     {
       code: 'await waitForApiResponse(\'/api/users\', \'GET\')',
-      filename: 'users.test.js',
-      errors: [{ messageId: 'cachedApiWait' }]
-    },
-    // 1.3 — No method anywhere (implicit GET default) still flags
-    {
-      code: 'await waitForApiResponse(\'/api/users\')',
       filename: 'users.test.js',
       errors: [{ messageId: 'cachedApiWait' }]
     },


### PR DESCRIPTION
## Existing Behavior

- No ESLint rule existed to detect waits on cached/GET API responses in tests.
- Calls to `page.waitForResponse(...)` and custom helper functions like `waitForApiResponse(...)` with implicit or explicit GET methods were silently allowed.
- The `recommended` and `strict` configs had no coverage for this class of flakiness.

## Intended New Behavior

- A new `no-cached-api-wait` rule flags any `waitForResponse`/`waitForApiResponse` call (and configurable custom helpers) whose HTTP method is GET (explicit or implicit default), since GET responses can be served from cache and are an unreliable wait signal.
- Waits on mutation methods (`POST`, `PUT`, `DELETE`, `PATCH`) and non-literal method values (variables, template literals) are intentionally not flagged — the rule stays conservative.
- The rule is registered at `error` severity in both the `recommended` and `strict` configs.
- Full options schema lets consumers override `flagMethods` (e.g. add `HEAD`) and `helperNames` (replace defaults with project-specific helper names).
- A dedicated rule doc (`docs/rules/no-cached-api-wait.md`) and README table entries are included.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify the rule fires on a GET wait:**

1. In any test file (e.g. `foo.test.js`), add:
   ```js
   await waitForApiResponse({ url: '/api/users' }); // no method → implicit GET
   ```
2. Run `pnpm lint` — expect an error: `Avoid waiting on the cached API response…`

**Verify mutation methods are allowed:**

1. Change the call to `method: 'POST'` and re-run `pnpm lint` — no error expected.

**Verify `page.waitForResponse` is flagged unconditionally in test files:**

1. Add `await page.waitForResponse(resp => resp.url().includes('/api'))` to a `*.test.js` file.
2. Run `pnpm lint` — expect the `cachedApiWait` error.

**Verify non-test files are ignored:**

1. Place the same call in `src/app.js` and run `pnpm lint` — no error expected.

**Run the full test suite:**

```bash
pnpm exec jest
# Expected: 25 test suites, 1601 tests — all passing
```

### Test Results

25 test suites passed (1601 tests total), including:
- `tests/lib/rules/no-cached-api-wait.test.js` — valid and invalid cases via `RuleTester`
- `tests/lib/configs/no-cached-api-wait-registration.test.js` — config registration for `recommended` and `strict`

Closes #49

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turning the rule on in recommended/strict may surface new lint errors in Playwright/Cypress tests that rely on `waitForResponse`; behavior is conservative but adoption can require test refactors.
> 
> **Overview**
> Adds **`no-cached-api-wait`**, an ESLint rule that reports `waitForResponse` / `waitForApiResponse` (and configurable helpers) when tests wait on **GET or implicit-GET** network matchers instead of visible UI. It applies only in test files, skips mutation methods and non-static `method` values, and supports **`flagMethods`** and **`helperNames`**.
> 
> The rule is enabled at **`error`** in **`recommended`** and **`strict`**, with rule docs, README tables, RuleTester coverage, and a small config registration test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29459db1364e7e2363a46f5d020863c78fb4034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->