### PR TITLE
feat(rules): add no-fragile-locators rule for E2E specs

### DIFF
--- a/docs/rules/no-fragile-locators.md
+++ b/docs/rules/no-fragile-locators.md
@@ -1,34 +1,45 @@
 # no-fragile-locators
 
-Flag fragile Playwright locators (e.g. `getByText`, ambiguous `getByRole`) when they drive an interaction or wait in E2E spec files.
+Flag fragile Playwright locators (e.g. `getByText`, ambiguous `getByRole`) when they drive an interaction
+or wait in E2E spec files.
 
-This rule is **not enabled** in the `recommended` or `strict` configs. It encodes a stricter, opinionated stance than community defaults and must be opted into explicitly.
+This rule is **not enabled** in the `recommended` or `strict` configs. It encodes a stricter, opinionated
+stance than community defaults and must be opted into explicitly.
 
 ## Rule Details
 
-In Playwright E2E specs, fragile locators break when DOM structure, copy text, or ARIA roles change — and, more importantly for flakiness, they **race** when used to drive interactions. `data-testid` selectors are deterministic and immune to these issues.
+In Playwright E2E specs, fragile locators break when DOM structure, copy text, or ARIA roles change — and,
+more importantly for flakiness, they **race** when used to drive interactions. `data-testid` selectors are
+deterministic and immune to these issues.
 
 The key insight is that flakiness lives in **actions**, not **assertions**:
 
-- A fragile locator in an **assertion** (`expect(...)`) that is wrong fails loudly and deterministically — it is not flaky.
-- A fragile locator driving an **interaction or wait** (`.click()`, `.fill()`, `.waitFor()`, `.hover()`, …) races against DOM/copy/role changes and ambiguous matches — this is what flakes.
+- A fragile locator in an **assertion** (`expect(...)`) that is wrong fails loudly and deterministically —
+  it is not flaky.
+- A fragile locator driving an **interaction or wait** (`.click()`, `.fill()`, `.waitFor()`, `.hover()`, …)
+  races against DOM/copy/role changes and ambiguous matches — this is what flakes.
 
-So this rule targets fragile locators in **action/wait position** and leaves **assertion position** unrestricted. This keeps the readable, accessibility-aligned assertions that Playwright and Testing Library encourage, while forcing the lines that actually flake onto stable hooks.
+So this rule targets fragile locators in **action/wait position** and leaves **assertion position**
+unrestricted. This keeps the readable, accessibility-aligned assertions that Playwright and Testing Library
+encourage, while forcing the lines that actually flake onto stable hooks.
 
 ### What counts as "fragile"
 
 - `getByText` — copy-coupled, always treated as fragile.
-- `getByRole` **without a `{ name }` option** — ambiguous matches cause strict-mode races. `getByRole(role, { name })` is **not** flagged by default.
+- `getByRole` **without a `{ name }` option** — ambiguous matches cause strict-mode races.
+  `getByRole(role, { name })` is **not** flagged by default.
 - `getByLabel` is **not** flagged by default (stable for form fields).
 
 ### What counts as an "action/wait"
 
 A fragile locator is flagged only when it is the receiver of one of these methods:
-`click`, `dblclick`, `fill`, `type`, `press`, `check`, `uncheck`, `selectOption`, `setInputFiles`, `hover`, `focus`, `dragTo`, `tap`, `waitFor`.
+`click`, `dblclick`, `fill`, `type`, `press`, `check`, `uncheck`, `selectOption`, `setInputFiles`, `hover`,
+`focus`, `dragTo`, `tap`, `waitFor`.
 
 ### Scope
 
-The rule applies only to E2E spec files (default `*.spec.ts`). It never applies to unit/component tests, where `getByRole` is the recommended primary locator.
+The rule applies only to E2E spec files (default `*.spec.ts`). It never applies to unit/component tests,
+where `getByRole` is the recommended primary locator.
 
 ## Examples
 
@@ -36,17 +47,17 @@ The rule applies only to E2E spec files (default `*.spec.ts`). It never applies 
 
 ```ts
 // fragile locator drives an interaction (races on copy/role/DOM change)
-await page.getByText('Add field').click();
+await page.getByText("Add field").click();
 
 // getByRole without a {name} option is ambiguous in action position
-await page.getByRole('button').click();
+await page.getByRole("button").click();
 
 // applies to all action/wait methods
-await page.getByText('x').fill('y');
-await page.getByText('x').waitFor();
+await page.getByText("x").fill("y");
+await page.getByText("x").waitFor();
 
 // stored-variable chains are resolved too
-const target = page.getByText('Add field');
+const target = page.getByText("Add field");
 await target.click();
 ```
 
@@ -54,18 +65,18 @@ await target.click();
 
 ```ts
 // stable locator drives the interaction
-await page.getByTestId('add-field-btn').click();
-await page.getByPlaceholder('Search').fill('hello');
+await page.getByTestId("add-field-btn").click();
+await page.getByPlaceholder("Search").fill("hello");
 
 // getByRole with a {name} option is disambiguated
-await page.getByRole('button', { name: 'Save' }).click();
+await page.getByRole("button", { name: "Save" }).click();
 
 // getByLabel is stable for form fields
-await page.getByLabel('Email').fill('a@b.com');
+await page.getByLabel("Email").fill("a@b.com");
 
 // fragile locator only asserts — deterministic failure, not flaky
-await expect(page.getByText('Field added')).toBeVisible();
-await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+await expect(page.getByText("Field added")).toBeVisible();
+await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 ```
 
 ## Options
@@ -79,8 +90,20 @@ This rule accepts an options object with the following properties:
     {
       "fragile": ["getByText"],
       "actionMethods": [
-        "click", "dblclick", "fill", "type", "press", "check", "uncheck",
-        "selectOption", "setInputFiles", "hover", "focus", "dragTo", "tap", "waitFor"
+        "click",
+        "dblclick",
+        "fill",
+        "type",
+        "press",
+        "check",
+        "uncheck",
+        "selectOption",
+        "setInputFiles",
+        "hover",
+        "focus",
+        "dragTo",
+        "tap",
+        "waitFor"
       ],
       "stable": ["getByTestId", "getByPlaceholder"],
       "flagRoleWithoutName": true,
@@ -90,25 +113,27 @@ This rule accepts an options object with the following properties:
 }
 ```
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `fragile` | `string[]` | `["getByText"]` | Locator factories treated as fragile when in action position. |
-| `actionMethods` | `string[]` | (list above) | Methods whose receiver is checked for a fragile locator. |
-| `stable` | `string[]` | `["getByTestId", "getByPlaceholder"]` | Locators considered safe — never flagged. |
-| `flagRoleWithoutName` | `boolean` | `true` | Also flag `getByRole(...)` used in action position when it has no `{ name }` option. |
-| `filePattern` | `string` | `"*.spec.ts"` | Only apply to files whose basename matches this glob (E2E spec files). |
+| Option                | Type       | Default                               | Description                                                                          |
+| --------------------- | ---------- | ------------------------------------- | ------------------------------------------------------------------------------------ |
+| `fragile`             | `string[]` | `["getByText"]`                       | Locator factories treated as fragile when in action position.                        |
+| `actionMethods`       | `string[]` | (list above)                          | Methods whose receiver is checked for a fragile locator.                             |
+| `stable`              | `string[]` | `["getByTestId", "getByPlaceholder"]` | Locators considered safe — never flagged.                                            |
+| `flagRoleWithoutName` | `boolean`  | `true`                                | Also flag `getByRole(...)` used in action position when it has no `{ name }` option. |
+| `filePattern`         | `string`   | `"*.spec.ts"`                         | Only apply to files whose basename matches this glob (E2E spec files).               |
 
 ## When Not To Use It
 
-- You do not write Playwright E2E specs, or your project standard is to drive interactions off user-facing locators rather than `data-testid`.
-- Your team intentionally follows the Playwright/Testing Library default priority that ranks `getByRole`/`getByText` above `getByTestId` even for actions.
+- You do not write Playwright E2E specs, or your project standard is to drive interactions off user-facing
+  locators rather than `data-testid`.
+- Your team intentionally follows the Playwright/Testing Library default priority that ranks
+  `getByRole`/`getByText` above `getByTestId` even for actions.
 - You rely on a different file-naming convention for E2E specs and do not want to configure `filePattern`.
 
 For one-off exceptions, disable the rule inline:
 
 ```ts
 // eslint-disable-next-line test-flakiness/no-fragile-locators
-await page.getByText('Add field').click();
+await page.getByText("Add field").click();
 ```
 
 ## Related Rules

--- a/docs/rules/no-fragile-locators.md
+++ b/docs/rules/no-fragile-locators.md
@@ -1,0 +1,123 @@
+# no-fragile-locators
+
+Flag fragile Playwright locators (e.g. `getByText`, ambiguous `getByRole`) when they drive an interaction or wait in E2E spec files.
+
+This rule is **not enabled** in the `recommended` or `strict` configs. It encodes a stricter, opinionated stance than community defaults and must be opted into explicitly.
+
+## Rule Details
+
+In Playwright E2E specs, fragile locators break when DOM structure, copy text, or ARIA roles change — and, more importantly for flakiness, they **race** when used to drive interactions. `data-testid` selectors are deterministic and immune to these issues.
+
+The key insight is that flakiness lives in **actions**, not **assertions**:
+
+- A fragile locator in an **assertion** (`expect(...)`) that is wrong fails loudly and deterministically — it is not flaky.
+- A fragile locator driving an **interaction or wait** (`.click()`, `.fill()`, `.waitFor()`, `.hover()`, …) races against DOM/copy/role changes and ambiguous matches — this is what flakes.
+
+So this rule targets fragile locators in **action/wait position** and leaves **assertion position** unrestricted. This keeps the readable, accessibility-aligned assertions that Playwright and Testing Library encourage, while forcing the lines that actually flake onto stable hooks.
+
+### What counts as "fragile"
+
+- `getByText` — copy-coupled, always treated as fragile.
+- `getByRole` **without a `{ name }` option** — ambiguous matches cause strict-mode races. `getByRole(role, { name })` is **not** flagged by default.
+- `getByLabel` is **not** flagged by default (stable for form fields).
+
+### What counts as an "action/wait"
+
+A fragile locator is flagged only when it is the receiver of one of these methods:
+`click`, `dblclick`, `fill`, `type`, `press`, `check`, `uncheck`, `selectOption`, `setInputFiles`, `hover`, `focus`, `dragTo`, `tap`, `waitFor`.
+
+### Scope
+
+The rule applies only to E2E spec files (default `*.spec.ts`). It never applies to unit/component tests, where `getByRole` is the recommended primary locator.
+
+## Examples
+
+### Incorrect
+
+```ts
+// fragile locator drives an interaction (races on copy/role/DOM change)
+await page.getByText('Add field').click();
+
+// getByRole without a {name} option is ambiguous in action position
+await page.getByRole('button').click();
+
+// applies to all action/wait methods
+await page.getByText('x').fill('y');
+await page.getByText('x').waitFor();
+
+// stored-variable chains are resolved too
+const target = page.getByText('Add field');
+await target.click();
+```
+
+### Correct
+
+```ts
+// stable locator drives the interaction
+await page.getByTestId('add-field-btn').click();
+await page.getByPlaceholder('Search').fill('hello');
+
+// getByRole with a {name} option is disambiguated
+await page.getByRole('button', { name: 'Save' }).click();
+
+// getByLabel is stable for form fields
+await page.getByLabel('Email').fill('a@b.com');
+
+// fragile locator only asserts — deterministic failure, not flaky
+await expect(page.getByText('Field added')).toBeVisible();
+await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+```
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+```json
+{
+  "test-flakiness/no-fragile-locators": [
+    "warn",
+    {
+      "fragile": ["getByText"],
+      "actionMethods": [
+        "click", "dblclick", "fill", "type", "press", "check", "uncheck",
+        "selectOption", "setInputFiles", "hover", "focus", "dragTo", "tap", "waitFor"
+      ],
+      "stable": ["getByTestId", "getByPlaceholder"],
+      "flagRoleWithoutName": true,
+      "filePattern": "*.spec.ts"
+    }
+  ]
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `fragile` | `string[]` | `["getByText"]` | Locator factories treated as fragile when in action position. |
+| `actionMethods` | `string[]` | (list above) | Methods whose receiver is checked for a fragile locator. |
+| `stable` | `string[]` | `["getByTestId", "getByPlaceholder"]` | Locators considered safe — never flagged. |
+| `flagRoleWithoutName` | `boolean` | `true` | Also flag `getByRole(...)` used in action position when it has no `{ name }` option. |
+| `filePattern` | `string` | `"*.spec.ts"` | Only apply to files whose basename matches this glob (E2E spec files). |
+
+## When Not To Use It
+
+- You do not write Playwright E2E specs, or your project standard is to drive interactions off user-facing locators rather than `data-testid`.
+- Your team intentionally follows the Playwright/Testing Library default priority that ranks `getByRole`/`getByText` above `getByTestId` even for actions.
+- You rely on a different file-naming convention for E2E specs and do not want to configure `filePattern`.
+
+For one-off exceptions, disable the rule inline:
+
+```ts
+// eslint-disable-next-line test-flakiness/no-fragile-locators
+await page.getByText('Add field').click();
+```
+
+## Related Rules
+
+- [no-index-queries](./no-index-queries.md) - Prevents fragile index-based (`.nth()`/`.eq()`) locator selection.
+- [no-long-text-match](./no-long-text-match.md) - Encourages partial text matching over brittle full-string matches.
+
+## Further Reading
+
+- [Playwright - Locators](https://playwright.dev/docs/locators)
+- [Playwright - Best Practices](https://playwright.dev/docs/best-practices)
+- [Testing Library - Priority](https://testing-library.com/docs/queries/about#priority)

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -83,19 +83,36 @@ function resolveFactory(object) {
 /**
  * Determine whether a `getByRole(...)` factory call carries a `{ name }` option.
  *
+ * When the options argument is not a statically-analyzable object literal (e.g.
+ * `getByRole('button', opts)` or `getByRole('button', { ...defaults })`), the
+ * rule cannot prove that `name` is absent, so it conservatively reports a name as
+ * present to avoid false positives.
+ *
  * @param {object} callNode - The factory CallExpression node.
- * @returns {boolean} True when a second-argument object has a `name` property.
+ * @returns {boolean} True when a second-argument object has (or may have) a `name` property.
  */
 function hasNameOption(callNode) {
   const arg = callNode.arguments && callNode.arguments[1];
-  if (!arg || arg.type !== 'ObjectExpression') {
+  if (!arg) {
     return false;
   }
-  return arg.properties.some((prop) =>
-    prop.type === 'Property' &&
-    ((prop.key.type === 'Identifier' && prop.key.name === 'name') ||
-     (prop.key.type === 'Literal' && prop.key.value === 'name'))
-  );
+  // Non-object-literal options (identifier, call, etc.) are opaque — assume name.
+  if (arg.type !== 'ObjectExpression') {
+    return true;
+  }
+  return arg.properties.some((prop) => {
+    // A spread (`{ ...opts }`) may contribute `name`; treat it as present.
+    if (prop.type === 'SpreadElement' || prop.type === 'ExperimentalSpreadProperty') {
+      return true;
+    }
+    // A computed key cannot be statically resolved; treat it as a possible name.
+    if (prop.type === 'Property' && prop.computed) {
+      return true;
+    }
+    return prop.type === 'Property' &&
+      ((prop.key.type === 'Identifier' && prop.key.name === 'name') ||
+       (prop.key.type === 'Literal' && prop.key.value === 'name'));
+  });
 }
 
 module.exports = {

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -45,24 +45,31 @@ function basename(filename) {
 }
 
 /**
- * Resolve the name of the innermost locator-factory call in a member/call chain.
+ * Resolve the fragility-determining locator-factory call in a member/call chain.
  *
- * Walks down the object side of a chain (e.g. `page.getByText('x')` or
- * `page.frameLocator(...).getByText('x')`) and returns the property name of the
- * first `CallExpression` whose callee is a `MemberExpression` (the factory call),
- * along with that call node so callers can inspect its arguments.
+ * Walks the entire object side of a chain (e.g. `page.getByText('x').first()` or
+ * `page.frameLocator(...).getByText('x').locator('button')`) inspecting every
+ * `CallExpression` whose callee is a `MemberExpression`. Refinement methods such as
+ * `.first()`/`.last()`/`.nth()`/`.filter()`/`.locator()` merely wrap the base
+ * locator, so the *innermost* factory call is what determines fragility. Returns
+ * that innermost factory's property name plus its call node so callers can
+ * inspect its arguments. Without this, patterns like
+ * `getByText('x').first().click()` would resolve to `first` and slip through.
  *
  * @param {object} object - The object side of the action's MemberExpression.
  * @returns {{name: string, call: object}|null} Factory info or null.
  */
 function resolveFactory(object) {
   let current = object;
+  let innermost = null;
   while (current) {
     if (current.type === 'CallExpression' &&
         current.callee && current.callee.type === 'MemberExpression') {
-      return { name: current.callee.property.name, call: current };
-    }
-    if (current.type === 'CallExpression') {
+      // Track the deepest factory call; each iteration moves inward, so the
+      // last one recorded is the underlying (innermost) locator factory.
+      innermost = { name: current.callee.property.name, call: current };
+      current = current.callee.object;
+    } else if (current.type === 'CallExpression') {
       current = current.callee;
     } else if (current.type === 'MemberExpression') {
       current = current.object;
@@ -70,7 +77,7 @@ function resolveFactory(object) {
       break;
     }
   }
-  return null;
+  return innermost;
 }
 
 /**

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -240,10 +240,17 @@ module.exports = {
      * Resolve an Identifier action-receiver to its originating factory call by
      * locating its most recent variable declaration in the current scope chain.
      *
+     * Follows alias inits (`const b = a`) by threading itself back into
+     * resolveFactory as the identifier resolver, while a `seen` set of resolved
+     * variables guards against infinite recursion on self-referential writes
+     * (e.g. `t = t.filter(...)`).
+     *
      * @param {object} identifier - The Identifier node used as the action receiver.
+     * @param {Set<object>} [seen] - Variables already being resolved (cycle guard).
      * @returns {object|null} The originating factory info, or null.
      */
-    function resolveIdentifierFactory(identifier) {
+    function resolveIdentifierFactory(identifier, seen) {
+      seen = seen || new Set();
       // ESLint 9 exposes scope via sourceCode.getScope(node); v7/v8 use context.getScope().
       const sourceCode = context.sourceCode || context.getSourceCode();
       let scope = (sourceCode && sourceCode.getScope)
@@ -253,6 +260,12 @@ module.exports = {
       while (scope) {
         const variable = scope.variables.find((v) => v.name === identifier.name);
         if (variable) {
+          // Cycle guard: a self-referential write (`t = t.filter(...)`) would
+          // otherwise recurse forever through the resolver threaded below.
+          if (seen.has(variable)) {
+            return null;
+          }
+          seen.add(variable);
           // Collect every write to the binding — the declarator initializer and
           // any later AssignmentExpression updates — then pick the most recent
           // one that precedes the action-receiver usage. This avoids tying the
@@ -286,7 +299,10 @@ module.exports = {
           }
 
           if (latestWrite) {
-            return resolveFactory(latestWrite, classifyFactory);
+            // Pass the resolver so an alias init (`const b = a`) follows `a` back
+            // to its factory; the shared `seen` set keeps the walk acyclic.
+            return resolveFactory(latestWrite, classifyFactory, (id) =>
+              resolveIdentifierFactory(id, seen));
           }
           // Binding found but no resolvable write before the usage (e.g. declared
           // without initializer); stop walking outer scopes — it is shadowed here.

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -158,14 +158,48 @@ module.exports = {
       let scope = (sourceCode && sourceCode.getScope)
         ? sourceCode.getScope(identifier)
         : context.getScope();
+      const useStart = identifier.range ? identifier.range[0] : Infinity;
       while (scope) {
         const variable = scope.variables.find((v) => v.name === identifier.name);
         if (variable) {
+          // Collect every write to the binding — the declarator initializer and
+          // any later AssignmentExpression updates — then pick the most recent
+          // one that precedes the action-receiver usage. This avoids tying the
+          // receiver to a stale declaration `init` when the locator is reassigned.
+          let latestWrite = null;
+          let latestWriteStart = -Infinity;
+
           for (const def of variable.defs) {
-            if (def.node && def.node.type === 'VariableDeclarator' && def.node.init) {
-              return resolveFactory(def.node.init);
+            if (
+              def.node &&
+              def.node.type === 'VariableDeclarator' &&
+              def.node.init &&
+              def.node.range &&
+              def.node.range[0] < useStart &&
+              def.node.range[0] > latestWriteStart
+            ) {
+              latestWrite = def.node.init;
+              latestWriteStart = def.node.range[0];
             }
           }
+
+          for (const ref of variable.references) {
+            if (!ref.isWrite() || !ref.writeExpr || !ref.writeExpr.range) {
+              continue;
+            }
+            const writeStart = ref.writeExpr.range[0];
+            if (writeStart < useStart && writeStart > latestWriteStart) {
+              latestWrite = ref.writeExpr;
+              latestWriteStart = writeStart;
+            }
+          }
+
+          if (latestWrite) {
+            return resolveFactory(latestWrite);
+          }
+          // Binding found but no resolvable write before the usage (e.g. declared
+          // without initializer); stop walking outer scopes — it is shadowed here.
+          return null;
         }
         scope = scope.upper;
       }

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -65,11 +65,18 @@ function basename(filename) {
  *   3. otherwise the innermost call as a fallback, preserving prior behavior for
  *      refinement-only chains (`page.locator('x').click()`).
  *
+ * When the chain bottoms out at an Identifier (a stored locator such as
+ * `const tgt = page.getByText('x'); tgt.first().click()`), the optional
+ * `resolveIdentifier` resolver ties that base variable back to its originating
+ * factory so refinements on a stored fragile locator are flagged just like the
+ * inlined form.
+ *
  * @param {object} object - The object side of the action's MemberExpression.
  * @param {(name: string) => ('fragile'|'stable'|null)} classify - Factory classifier.
+ * @param {(id: object) => ({name: string, call: object}|null)} [resolveIdentifier] - Resolves an Identifier base to its factory.
  * @returns {{name: string, call: object}|null} Factory info or null.
  */
-function resolveFactory(object, classify) {
+function resolveFactory(object, classify, resolveIdentifier) {
   let current = object;
   let firstCandidate = null;
   let firstStable = null;
@@ -91,6 +98,21 @@ function resolveFactory(object, classify) {
       current = current.callee;
     } else if (current.type === 'MemberExpression') {
       current = current.object;
+    } else if (current.type === 'Identifier' && resolveIdentifier) {
+      // Stored-locator base: resolve the variable to its originating factory and
+      // fold it in as the innermost call so `tgt.first().click()` is treated the
+      // same as `page.getByText('x').first().click()`.
+      const resolved = resolveIdentifier(current);
+      if (resolved) {
+        const kind = classify(resolved.name);
+        if (kind === 'fragile' && !firstCandidate) {
+          firstCandidate = resolved;
+        } else if (kind === 'stable' && !firstStable) {
+          firstStable = resolved;
+        }
+        innermost = resolved;
+      }
+      break;
     } else {
       break;
     }
@@ -309,7 +331,7 @@ module.exports = {
         const receiver = node.callee.object;
         const factory = receiver.type === 'Identifier'
           ? resolveIdentifierFactory(receiver)
-          : resolveFactory(receiver, classifyFactory);
+          : resolveFactory(receiver, classifyFactory, resolveIdentifierFactory);
 
         if (isFragileFactory(factory)) {
           context.report({

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -47,27 +47,45 @@ function basename(filename) {
 /**
  * Resolve the fragility-determining locator-factory call in a member/call chain.
  *
- * Walks the entire object side of a chain (e.g. `page.getByText('x').first()` or
- * `page.frameLocator(...).getByText('x').locator('button')`) inspecting every
- * `CallExpression` whose callee is a `MemberExpression`. Refinement methods such as
- * `.first()`/`.last()`/`.nth()`/`.filter()`/`.locator()` merely wrap the base
- * locator, so the *innermost* factory call is what determines fragility. Returns
- * that innermost factory's property name plus its call node so callers can
- * inspect its arguments. Without this, patterns like
- * `getByText('x').first().click()` would resolve to `first` and slip through.
+ * Walks the entire object side of a chain (e.g. `page.getByText('x').first()`,
+ * `page.frameLocator(...).getByText('x')` or `page.getByText('x').locator('button')`)
+ * collecting every `CallExpression` whose callee is a `MemberExpression`. Both
+ * scoping methods (`frameLocator()`/`locator()`) and refinement methods
+ * (`.first()`/`.last()`/`.nth()`/`.filter()`/`.locator()`) merely wrap a base
+ * locator, so neither the outermost nor the innermost call reliably identifies
+ * fragility on its own: `getByText('x').first()` needs the inner `getByText`,
+ * while `frameLocator('#f').getByText('x')` needs the outer `getByText`.
+ *
+ * Resolution therefore classifies each factory and selects the relevant one:
+ *   1. the first fragile candidate (a `fragile` factory or `getByRole`) found
+ *      walking inward — a fragile sub-locator is never rescued by a stable or
+ *      scoping wrapper;
+ *   2. otherwise the first stable factory — so a genuinely stable chain is not
+ *      flagged;
+ *   3. otherwise the innermost call as a fallback, preserving prior behavior for
+ *      refinement-only chains (`page.locator('x').click()`).
  *
  * @param {object} object - The object side of the action's MemberExpression.
+ * @param {(name: string) => ('fragile'|'stable'|null)} classify - Factory classifier.
  * @returns {{name: string, call: object}|null} Factory info or null.
  */
-function resolveFactory(object) {
+function resolveFactory(object, classify) {
   let current = object;
+  let firstCandidate = null;
+  let firstStable = null;
   let innermost = null;
   while (current) {
     if (current.type === 'CallExpression' &&
         current.callee && current.callee.type === 'MemberExpression') {
-      // Track the deepest factory call; each iteration moves inward, so the
-      // last one recorded is the underlying (innermost) locator factory.
-      innermost = { name: current.callee.property.name, call: current };
+      const factory = { name: current.callee.property.name, call: current };
+      const kind = classify(factory.name);
+      if (kind === 'fragile' && !firstCandidate) {
+        firstCandidate = factory;
+      } else if (kind === 'stable' && !firstStable) {
+        firstStable = factory;
+      }
+      // Each iteration moves inward, so the last one recorded is the innermost.
+      innermost = factory;
       current = current.callee.object;
     } else if (current.type === 'CallExpression') {
       current = current.callee;
@@ -77,7 +95,7 @@ function resolveFactory(object) {
       break;
     }
   }
-  return innermost;
+  return firstCandidate || firstStable || innermost;
 }
 
 /**
@@ -176,6 +194,27 @@ module.exports = {
     }
 
     /**
+     * Classify a factory name so resolveFactory can pick the fragility-relevant
+     * call in a chain. `getByRole` is always a candidate (its fragility depends
+     * on the presence of a `name` option, decided later by isFragileFactory).
+     *
+     * @param {string} name - The factory method name.
+     * @returns {'fragile'|'stable'|null} Its classification.
+     */
+    function classifyFactory(name) {
+      if (name === 'getByRole') {
+        return 'fragile';
+      }
+      if (fragile.includes(name)) {
+        return 'fragile';
+      }
+      if (stable.includes(name)) {
+        return 'stable';
+      }
+      return null;
+    }
+
+    /**
      * Resolve an Identifier action-receiver to its originating factory call by
      * locating its most recent variable declaration in the current scope chain.
      *
@@ -225,7 +264,7 @@ module.exports = {
           }
 
           if (latestWrite) {
-            return resolveFactory(latestWrite);
+            return resolveFactory(latestWrite, classifyFactory);
           }
           // Binding found but no resolvable write before the usage (e.g. declared
           // without initializer); stop walking outer scopes — it is shadowed here.
@@ -270,7 +309,7 @@ module.exports = {
         const receiver = node.callee.object;
         const factory = receiver.type === 'Identifier'
           ? resolveIdentifierFactory(receiver)
-          : resolveFactory(receiver);
+          : resolveFactory(receiver, classifyFactory);
 
         if (isFragileFactory(factory)) {
           context.report({

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -1,0 +1,221 @@
+/**
+ * @fileoverview Rule to flag fragile Playwright locators used in action position
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const { getFilename } = require('../utils/helpers');
+
+const DEFAULT_FRAGILE = ['getByText'];
+const DEFAULT_ACTION_METHODS = [
+  'click', 'dblclick', 'fill', 'type', 'press', 'check', 'uncheck',
+  'selectOption', 'setInputFiles', 'hover', 'focus', 'dragTo', 'tap', 'waitFor'
+];
+const DEFAULT_STABLE = ['getByTestId', 'getByPlaceholder'];
+const DEFAULT_FILE_PATTERN = '*.spec.ts';
+
+/**
+ * Convert a simple file glob to a bounded, anchored regex.
+ *
+ * Only `*` is treated as a wildcard (matching any run of non-`/` characters);
+ * every other character is escaped to a literal. The result is fully anchored
+ * (`^…$`) and uses only the bounded quantifier `[^/]*`, so it has no catastrophic
+ * backtracking surface (ReDoS-safe) and needs no `minimatch` dependency.
+ *
+ * @param {string} glob - The glob pattern, e.g. `"*.spec.ts"`.
+ * @returns {RegExp} An anchored, ReDoS-safe regex matching a basename.
+ */
+function globToRegExp(glob) {
+  const escaped = glob.replace(/[.*+?^${}()|[\]\\]/g, (ch) =>
+    ch === '*' ? '[^/]*' : `\\${ch}`
+  );
+  return new RegExp(`^${escaped}$`);
+}
+
+/**
+ * Extract the basename (final path segment) from a filename.
+ *
+ * @param {string} filename - Full or relative filename.
+ * @returns {string} The basename.
+ */
+function basename(filename) {
+  const normalized = String(filename).replace(/\\/g, '/');
+  const idx = normalized.lastIndexOf('/');
+  return idx === -1 ? normalized : normalized.slice(idx + 1);
+}
+
+/**
+ * Resolve the name of the innermost locator-factory call in a member/call chain.
+ *
+ * Walks down the object side of a chain (e.g. `page.getByText('x')` or
+ * `page.frameLocator(...).getByText('x')`) and returns the property name of the
+ * first `CallExpression` whose callee is a `MemberExpression` (the factory call),
+ * along with that call node so callers can inspect its arguments.
+ *
+ * @param {object} object - The object side of the action's MemberExpression.
+ * @returns {{name: string, call: object}|null} Factory info or null.
+ */
+function resolveFactory(object) {
+  let current = object;
+  while (current) {
+    if (current.type === 'CallExpression' &&
+        current.callee && current.callee.type === 'MemberExpression') {
+      return { name: current.callee.property.name, call: current };
+    }
+    if (current.type === 'CallExpression') {
+      current = current.callee;
+    } else if (current.type === 'MemberExpression') {
+      current = current.object;
+    } else {
+      break;
+    }
+  }
+  return null;
+}
+
+/**
+ * Determine whether a `getByRole(...)` factory call carries a `{ name }` option.
+ *
+ * @param {object} callNode - The factory CallExpression node.
+ * @returns {boolean} True when a second-argument object has a `name` property.
+ */
+function hasNameOption(callNode) {
+  const arg = callNode.arguments && callNode.arguments[1];
+  if (!arg || arg.type !== 'ObjectExpression') {
+    return false;
+  }
+  return arg.properties.some((prop) =>
+    prop.type === 'Property' &&
+    ((prop.key.type === 'Identifier' && prop.key.name === 'name') ||
+     (prop.key.type === 'Literal' && prop.key.value === 'name'))
+  );
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Flag fragile Playwright locators (e.g. getByText) when they drive an action',
+      category: 'Best Practices',
+      recommended: false,
+      url: 'https://github.com/tigredonorte/eslint-plugin-test-flakiness/blob/main/docs/rules/no-fragile-locators.md'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          fragile: {
+            type: 'array',
+            items: { type: 'string' }
+          },
+          actionMethods: {
+            type: 'array',
+            items: { type: 'string' }
+          },
+          stable: {
+            type: 'array',
+            items: { type: 'string' }
+          },
+          flagRoleWithoutName: {
+            type: 'boolean'
+          },
+          filePattern: {
+            type: 'string'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      fragileAction: 'Avoid driving `{{method}}` off a fragile locator (`{{factory}}`); use getByTestId instead.'
+    }
+  },
+
+  create(context) {
+    const options = (context.options && context.options[0]) || {};
+    const fragile = options.fragile || DEFAULT_FRAGILE;
+    const actionMethods = options.actionMethods || DEFAULT_ACTION_METHODS;
+    const stable = options.stable || DEFAULT_STABLE;
+    const flagRoleWithoutName = options.flagRoleWithoutName !== false;
+    const filePattern = options.filePattern || DEFAULT_FILE_PATTERN;
+
+    // E2E-spec-scoped only: bail early when the basename does not match filePattern.
+    const fileRegex = globToRegExp(filePattern);
+    if (!fileRegex.test(basename(getFilename(context)))) {
+      return {};
+    }
+
+    /**
+     * Resolve an Identifier action-receiver to its originating factory call by
+     * locating its most recent variable declaration in the current scope chain.
+     *
+     * @param {object} identifier - The Identifier node used as the action receiver.
+     * @returns {object|null} The originating factory info, or null.
+     */
+    function resolveIdentifierFactory(identifier) {
+      // ESLint 9 exposes scope via sourceCode.getScope(node); v7/v8 use context.getScope().
+      const sourceCode = context.sourceCode || context.getSourceCode();
+      let scope = (sourceCode && sourceCode.getScope)
+        ? sourceCode.getScope(identifier)
+        : context.getScope();
+      while (scope) {
+        const variable = scope.variables.find((v) => v.name === identifier.name);
+        if (variable) {
+          for (const def of variable.defs) {
+            if (def.node && def.node.type === 'VariableDeclarator' && def.node.init) {
+              return resolveFactory(def.node.init);
+            }
+          }
+        }
+        scope = scope.upper;
+      }
+      return null;
+    }
+
+    /**
+     * Decide whether a resolved factory is fragile under the current options.
+     *
+     * @param {{name: string, call: object}} factory - Resolved factory info.
+     * @returns {boolean} True when the factory should be flagged.
+     */
+    function isFragileFactory(factory) {
+      if (!factory) {
+        return false;
+      }
+      if (stable.includes(factory.name)) {
+        return false;
+      }
+      if (factory.name === 'getByRole') {
+        return flagRoleWithoutName && !hasNameOption(factory.call);
+      }
+      return fragile.includes(factory.name);
+    }
+
+    return {
+      // Assertion immunity holds by construction: we only ever report on an
+      // action CallExpression, never on a bare locator passed to expect(...).
+      CallExpression(node) {
+        if (node.callee.type !== 'MemberExpression') {
+          return;
+        }
+        const method = node.callee.property.name;
+        if (!actionMethods.includes(method)) {
+          return;
+        }
+
+        const receiver = node.callee.object;
+        const factory = receiver.type === 'Identifier'
+          ? resolveIdentifierFactory(receiver)
+          : resolveFactory(receiver);
+
+        if (isFragileFactory(factory)) {
+          context.report({
+            node,
+            messageId: 'fragileAction',
+            data: { method, factory: factory.name }
+          });
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -151,7 +151,7 @@ module.exports = {
       }
     ],
     messages: {
-      fragileAction: 'Avoid driving `{{method}}` off a fragile locator (`{{factory}}`); use getByTestId instead.'
+      fragileAction: 'Avoid driving `{{method}}` off a fragile locator (`{{factory}}`); prefer a stable locator ({{suggestion}}) instead.'
     }
   },
 
@@ -160,6 +160,12 @@ module.exports = {
     const fragile = options.fragile || DEFAULT_FRAGILE;
     const actionMethods = options.actionMethods || DEFAULT_ACTION_METHODS;
     const stable = options.stable || DEFAULT_STABLE;
+    // Build the human-readable list of preferred stable locators for the report
+    // message, instead of hard-coding `getByTestId`, so configured/custom stable
+    // factories are reflected accurately. Falls back to `getByTestId` when empty.
+    const stableSuggestion = (stable.length ? stable : ['getByTestId'])
+      .map((name) => `\`${name}\``)
+      .join(' or ');
     const flagRoleWithoutName = options.flagRoleWithoutName !== false;
     const filePattern = options.filePattern || DEFAULT_FILE_PATTERN;
 
@@ -270,7 +276,7 @@ module.exports = {
           context.report({
             node,
             messageId: 'fragileAction',
-            data: { method, factory: factory.name }
+            data: { method, factory: factory.name, suggestion: stableSuggestion }
           });
         }
       }

--- a/lib/rules/no-fragile-locators.js
+++ b/lib/rules/no-fragile-locators.js
@@ -85,7 +85,7 @@ function resolveFactory(object, classify, resolveIdentifier) {
     if (current.type === 'CallExpression' &&
         current.callee && current.callee.type === 'MemberExpression') {
       const factory = { name: current.callee.property.name, call: current };
-      const kind = classify(factory.name);
+      const kind = classify(factory.name, factory.call);
       if (kind === 'fragile' && !firstCandidate) {
         firstCandidate = factory;
       } else if (kind === 'stable' && !firstStable) {
@@ -104,7 +104,7 @@ function resolveFactory(object, classify, resolveIdentifier) {
       // same as `page.getByText('x').first().click()`.
       const resolved = resolveIdentifier(current);
       if (resolved) {
-        const kind = classify(resolved.name);
+        const kind = classify(resolved.name, resolved.call);
         if (kind === 'fragile' && !firstCandidate) {
           firstCandidate = resolved;
         } else if (kind === 'stable' && !firstStable) {
@@ -216,16 +216,21 @@ module.exports = {
     }
 
     /**
-     * Classify a factory name so resolveFactory can pick the fragility-relevant
-     * call in a chain. `getByRole` is always a candidate (its fragility depends
-     * on the presence of a `name` option, decided later by isFragileFactory).
+     * Classify a factory so resolveFactory can pick the fragility-relevant call
+     * in a chain. `getByRole` is only a fragile candidate when it lacks a `name`
+     * option (and role-without-name flagging is enabled); a named getByRole is a
+     * safe locator, so it is classified `stable` and the walk continues inward to
+     * surface any nested fragile factory (e.g. an inner `getByText`).
      *
      * @param {string} name - The factory method name.
+     * @param {object} [callNode] - The factory CallExpression, needed for getByRole.
      * @returns {'fragile'|'stable'|null} Its classification.
      */
-    function classifyFactory(name) {
+    function classifyFactory(name, callNode) {
       if (name === 'getByRole') {
-        return 'fragile';
+        // Conservative when the call node is unavailable: treat as fragile.
+        const named = callNode ? hasNameOption(callNode) : false;
+        return (flagRoleWithoutName && !named) ? 'fragile' : 'stable';
       }
       if (fragile.includes(name)) {
         return 'fragile';

--- a/tests/lib/index.test.js
+++ b/tests/lib/index.test.js
@@ -38,4 +38,25 @@ describe('eslint-plugin-test-flakiness', () => {
     expect(recommendedConfig.plugins).toEqual(['test-flakiness']);
     expect(strictConfig.plugins).toEqual(['test-flakiness']);
   });
+
+  describe('no-fragile-locators registration', () => {
+    const RULE_NAME = 'no-fragile-locators';
+    const QUALIFIED = `test-flakiness/${RULE_NAME}`;
+
+    it('auto-registers the rule in plugin.rules', () => {
+      expect(plugin.rules[RULE_NAME]).toBeDefined();
+    });
+
+    it('enables the rule in configs.all', () => {
+      expect(plugin.configs.all.rules[QUALIFIED]).toBe('error');
+    });
+
+    it('is off by default — absent from recommended', () => {
+      expect(plugin.configs.recommended.rules).not.toHaveProperty(QUALIFIED);
+    });
+
+    it('is off by default — absent from strict', () => {
+      expect(plugin.configs.strict.rules).not.toHaveProperty(QUALIFIED);
+    });
+  });
 });

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -103,7 +103,7 @@ ruleTester.run('no-fragile-locators', rule, {
       errors: [
         {
           messageId: 'fragileAction',
-          data: { method: 'click', factory: 'getByText' }
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
         }
       ]
     },
@@ -114,7 +114,7 @@ ruleTester.run('no-fragile-locators', rule, {
       errors: [
         {
           messageId: 'fragileAction',
-          data: { method: 'fill', factory: 'getByText' }
+          data: { method: 'fill', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
         }
       ]
     },
@@ -125,7 +125,7 @@ ruleTester.run('no-fragile-locators', rule, {
       errors: [
         {
           messageId: 'fragileAction',
-          data: { method: 'waitFor', factory: 'getByText' }
+          data: { method: 'waitFor', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
         }
       ]
     },
@@ -137,7 +137,7 @@ ruleTester.run('no-fragile-locators', rule, {
       errors: [
         {
           messageId: 'fragileAction',
-          data: { method: 'click', factory: 'getByRole' }
+          data: { method: 'click', factory: 'getByRole', suggestion: '`getByTestId` or `getByPlaceholder`' }
         }
       ]
     },
@@ -149,7 +149,7 @@ ruleTester.run('no-fragile-locators', rule, {
       errors: [
         {
           messageId: 'fragileAction',
-          data: { method: 'click', factory: 'getByText' }
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
         }
       ]
     },
@@ -162,7 +162,7 @@ ruleTester.run('no-fragile-locators', rule, {
       errors: [
         {
           messageId: 'fragileAction',
-          data: { method: 'click', factory: 'getByText' }
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
         }
       ]
     },
@@ -174,7 +174,7 @@ ruleTester.run('no-fragile-locators', rule, {
       errors: [
         {
           messageId: 'fragileAction',
-          data: { method: 'click', factory: 'getByText' }
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
         }
       ]
     },
@@ -186,7 +186,21 @@ ruleTester.run('no-fragile-locators', rule, {
       errors: [
         {
           messageId: 'fragileAction',
-          data: { method: 'click', factory: 'getByText' }
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
+        }
+      ]
+    },
+
+    // 1.6 the suggested stable alternative reflects a custom `stable` option
+    // rather than a hard-coded getByTestId.
+    {
+      code: spec('await page.getByText(\'x\').click()'),
+      filename: 'login.spec.ts',
+      options: [{ stable: ['getByLabel'] }],
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByLabel`' }
         }
       ]
     }

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -112,6 +112,13 @@ ruleTester.run('no-fragile-locators', rule, {
     {
       code: spec('const a = page.getByTestId(\'x\'); const b = a; await b.click();'),
       filename: 'login.spec.ts'
+    },
+
+
+    // 1.3 a named getByRole scoped within a stable locator stays allowed.
+    {
+      code: spec('await page.getByTestId(\'row\').getByRole(\'button\', { name: \'Save\' }).click()'),
+      filename: 'login.spec.ts'
     }
   ],
   invalid: [
@@ -251,6 +258,18 @@ ruleTester.run('no-fragile-locators', rule, {
     // 1.5 aliasing a fragile locator (const b = a) resolves back to getByText.
     {
       code: spec('const a = page.getByText(\'x\'); const b = a; await b.click();'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
+        }
+      ]
+    },
+
+    // 1.5 a named getByRole must not mask an inner fragile getByText scope.
+    {
+      code: spec('await page.getByText(\'x\').getByRole(\'button\', { name: \'Save\' }).click()'),
       filename: 'login.spec.ts',
       errors: [
         {

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -68,6 +68,13 @@ ruleTester.run('no-fragile-locators', rule, {
     {
       code: spec('await expect(page.getByRole(\'heading\', { name: \'Settings\' })).toBeVisible()'),
       filename: 'login.spec.ts'
+    },
+
+    // 1.4 reassignment: a let initialised fragile then reassigned to a stable
+    // locator before the action resolves to the latest (stable) write.
+    {
+      code: spec('let tgt = page.getByText(\'x\'); tgt = page.getByTestId(\'y\'); await tgt.click();'),
+      filename: 'login.spec.ts'
     }
   ],
   invalid: [
@@ -120,6 +127,19 @@ ruleTester.run('no-fragile-locators', rule, {
     // 1.4 stored-variable chain: fragile locator stored then driven via an action is flagged.
     {
       code: spec('const tgt = page.getByText(\'x\'); await tgt.click();'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText' }
+        }
+      ]
+    },
+
+    // 1.4 reassignment: a let initialised stable then reassigned to a fragile
+    // locator before the action resolves to the latest (fragile) write.
+    {
+      code: spec('let tgt = page.getByTestId(\'y\'); tgt = page.getByText(\'x\'); await tgt.click();'),
       filename: 'login.spec.ts',
       errors: [
         {

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Tests for no-fragile-locators rule
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/no-fragile-locators');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
+
+const ruleTester = getRuleTester();
+
+// Wrap action code in an async function so `await` is valid across ESLint 7/8/9.
+const spec = (body) => `async function t() { ${body} }`;
+
+describe('no-fragile-locators', () => {
+  test('rule module exposes the standard ESLint shape', () => {
+    expect(rule).toBeDefined();
+    expect(rule.meta).toBeDefined();
+    expect(typeof rule.create).toBe('function');
+  });
+});
+
+ruleTester.run('no-fragile-locators', rule, {
+  valid: [
+    // 1.1 filePattern scoping: identical fragile-in-action source in a non-spec file is not flagged.
+    {
+      code: spec('await page.getByText(\'Add field\').click()'),
+      filename: 'button.test.ts'
+    },
+
+    // 1.2 stable locators driving an action are allowed.
+    {
+      code: spec('await page.getByTestId(\'add-field-btn\').click()'),
+      filename: 'login.spec.ts'
+    },
+    {
+      code: spec('await page.getByPlaceholder(\'Search\').fill(\'hi\')'),
+      filename: 'login.spec.ts'
+    },
+    // 1.2 fragile factory followed by a non-action method is allowed.
+    {
+      code: spec('await page.getByText(\'x\').textContent()'),
+      filename: 'login.spec.ts'
+    },
+
+    // 1.3 getByRole with a {name} option driving an action is allowed.
+    {
+      code: spec('await page.getByRole(\'button\', { name: \'Save\' }).click()'),
+      filename: 'login.spec.ts'
+    },
+    // 1.3 getByRole without a name is allowed when flagRoleWithoutName is false.
+    {
+      code: spec('await page.getByRole(\'button\').click()'),
+      filename: 'login.spec.ts',
+      options: [{ flagRoleWithoutName: false }]
+    },
+    // 1.3 getByLabel driving an action is allowed by default.
+    {
+      code: spec('await page.getByLabel(\'Email\').fill(\'a@b.com\')'),
+      filename: 'login.spec.ts'
+    },
+
+    // 1.4 assertion immunity: fragile locator only passed to expect(...) is allowed.
+    {
+      code: spec('await expect(page.getByText(\'Field added\')).toBeVisible()'),
+      filename: 'login.spec.ts'
+    },
+    {
+      code: spec('await expect(page.getByRole(\'heading\', { name: \'Settings\' })).toBeVisible()'),
+      filename: 'login.spec.ts'
+    }
+  ],
+  invalid: [
+    // 1.1 / 1.2 getByText driving a click in a spec file is flagged.
+    {
+      code: spec('await page.getByText(\'Add field\').click()'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText' }
+        }
+      ]
+    },
+    // 1.2 getByText driving fill is flagged.
+    {
+      code: spec('await page.getByText(\'x\').fill(\'y\')'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'fill', factory: 'getByText' }
+        }
+      ]
+    },
+    // 1.2 getByText driving waitFor is flagged.
+    {
+      code: spec('await page.getByText(\'x\').waitFor()'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'waitFor', factory: 'getByText' }
+        }
+      ]
+    },
+
+    // 1.3 getByRole without a {name} option driving an action is flagged (default).
+    {
+      code: spec('await page.getByRole(\'button\').click()'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByRole' }
+        }
+      ]
+    },
+
+    // 1.4 stored-variable chain: fragile locator stored then driven via an action is flagged.
+    {
+      code: spec('const tgt = page.getByText(\'x\'); await tgt.click();'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText' }
+        }
+      ]
+    }
+  ]
+});

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -93,6 +93,13 @@ ruleTester.run('no-fragile-locators', rule, {
     {
       code: spec('await page.getByRole(\'button\', { ...defaults }).click()'),
       filename: 'login.spec.ts'
+    },
+
+    // 1.5 a stable factory scoped within frameLocator() stays allowed: scoping
+    // must not turn a stable locator into a false positive.
+    {
+      code: spec('await page.frameLocator(\'#f\').getByTestId(\'x\').click()'),
+      filename: 'login.spec.ts'
     }
   ],
   invalid: [
@@ -182,6 +189,31 @@ ruleTester.run('no-fragile-locators', rule, {
     // 1.5 fragile factory behind .locator() refinement is still flagged.
     {
       code: spec('await page.getByText(\'x\').locator(\'button\').click()'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
+        }
+      ]
+    },
+
+    // 1.5 fragile factory inside a frameLocator() scope is still flagged: the
+    // scoping call must not mask the underlying fragile getByText.
+    {
+      code: spec('await page.frameLocator(\'#f\').getByText(\'x\').click()'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
+        }
+      ]
+    },
+
+    // 1.5 fragile factory inside a locator() scope is still flagged.
+    {
+      code: spec('await page.locator(\'.scope\').getByText(\'x\').click()'),
       filename: 'login.spec.ts',
       errors: [
         {

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -81,6 +81,18 @@ ruleTester.run('no-fragile-locators', rule, {
     {
       code: spec('await page.getByTestId(\'row\').first().click()'),
       filename: 'login.spec.ts'
+    },
+
+    // 1.6 getByRole with an opaque (non-literal) options object is not flagged:
+    // the rule cannot prove the absence of a { name } option.
+    {
+      code: spec('await page.getByRole(\'button\', opts).click()'),
+      filename: 'login.spec.ts'
+    },
+    // 1.6 getByRole whose options spread an external object is not flagged.
+    {
+      code: spec('await page.getByRole(\'button\', { ...defaults }).click()'),
+      filename: 'login.spec.ts'
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -100,6 +100,12 @@ ruleTester.run('no-fragile-locators', rule, {
     {
       code: spec('await page.frameLocator(\'#f\').getByTestId(\'x\').click()'),
       filename: 'login.spec.ts'
+    },
+
+    // 1.5 stored stable locator refined before the action stays allowed.
+    {
+      code: spec('const tgt = page.getByTestId(\'x\'); await tgt.first().click();'),
+      filename: 'login.spec.ts'
     }
   ],
   invalid: [
@@ -214,6 +220,19 @@ ruleTester.run('no-fragile-locators', rule, {
     // 1.5 fragile factory inside a locator() scope is still flagged.
     {
       code: spec('await page.locator(\'.scope\').getByText(\'x\').click()'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
+        }
+      ]
+    },
+
+    // 1.5 stored fragile locator refined before the action is still flagged: the
+    // refinement on a stored variable must resolve back to getByText.
+    {
+      code: spec('const tgt = page.getByText(\'x\'); await tgt.first().click();'),
       filename: 'login.spec.ts',
       errors: [
         {

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -106,6 +106,12 @@ ruleTester.run('no-fragile-locators', rule, {
     {
       code: spec('const tgt = page.getByTestId(\'x\'); await tgt.first().click();'),
       filename: 'login.spec.ts'
+    },
+
+    // 1.5 aliasing a stable locator (const b = a) keeps it allowed.
+    {
+      code: spec('const a = page.getByTestId(\'x\'); const b = a; await b.click();'),
+      filename: 'login.spec.ts'
     }
   ],
   invalid: [
@@ -233,6 +239,18 @@ ruleTester.run('no-fragile-locators', rule, {
     // refinement on a stored variable must resolve back to getByText.
     {
       code: spec('const tgt = page.getByText(\'x\'); await tgt.first().click();'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText', suggestion: '`getByTestId` or `getByPlaceholder`' }
+        }
+      ]
+    },
+
+    // 1.5 aliasing a fragile locator (const b = a) resolves back to getByText.
+    {
+      code: spec('const a = page.getByText(\'x\'); const b = a; await b.click();'),
       filename: 'login.spec.ts',
       errors: [
         {

--- a/tests/lib/rules/no-fragile-locators.test.js
+++ b/tests/lib/rules/no-fragile-locators.test.js
@@ -75,6 +75,12 @@ ruleTester.run('no-fragile-locators', rule, {
     {
       code: spec('let tgt = page.getByText(\'x\'); tgt = page.getByTestId(\'y\'); await tgt.click();'),
       filename: 'login.spec.ts'
+    },
+
+    // 1.5 refinement chain off a stable factory stays allowed.
+    {
+      code: spec('await page.getByTestId(\'row\').first().click()'),
+      filename: 'login.spec.ts'
     }
   ],
   invalid: [
@@ -140,6 +146,30 @@ ruleTester.run('no-fragile-locators', rule, {
     // locator before the action resolves to the latest (fragile) write.
     {
       code: spec('let tgt = page.getByTestId(\'y\'); tgt = page.getByText(\'x\'); await tgt.click();'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText' }
+        }
+      ]
+    },
+
+    // 1.5 fragile factory behind .first() refinement is still flagged.
+    {
+      code: spec('await page.getByText(\'x\').first().click()'),
+      filename: 'login.spec.ts',
+      errors: [
+        {
+          messageId: 'fragileAction',
+          data: { method: 'click', factory: 'getByText' }
+        }
+      ]
+    },
+
+    // 1.5 fragile factory behind .locator() refinement is still flagged.
+    {
+      code: spec('await page.getByText(\'x\').locator(\'button\').click()'),
       filename: 'login.spec.ts',
       errors: [
         {


### PR DESCRIPTION
## Summary

Adds a new, off-by-default ESLint rule `test-flakiness/no-fragile-locators` that flags fragile Playwright locators when they drive an interaction or wait in E2E spec files.

The core insight: flakiness lives in **actions**, not **assertions**. A fragile locator driving an interaction (`.click()`, `.fill()`, `.waitFor()`, …) races against DOM/copy/role changes and ambiguous matches, whereas the same locator inside `expect(...)` fails deterministically. So the rule targets **action/wait position only** and leaves assertions unrestricted — keeping the readable, accessibility-aligned assertions that Playwright and Testing Library encourage.

## What counts as fragile

- `getByText` — copy-coupled, always fragile.
- `getByRole` **without** a `{ name }` option — ambiguous matches cause strict-mode races (`getByRole(role, { name })` is not flagged).
- `getByLabel` is not flagged (stable for form fields).

## Behavior

- Flags fragile locators only when the receiver of an action/wait method (`click`, `dblclick`, `fill`, `type`, `press`, `check`, `uncheck`, `selectOption`, `setInputFiles`, `hover`, `focus`, `dragTo`, `tap`, `waitFor`).
- Resolves both direct chains (`page.getByText('x').click()`) and stored-variable chains (`const t = page.getByText('x'); t.click()`).
- Scoped to E2E spec files via `filePattern` (default `*.spec.ts`); never applies to unit/component tests.
- Configurable: `fragile`, `actionMethods`, `stable`, `flagRoleWithoutName`, `filePattern`.

## Scope / config placement

- **Off by default** — auto-registered via `requireindex`, present only in `configs.all`, intentionally absent from `recommended` and `strict`. It encodes a stricter stance than community defaults and is opt-in.

## Tests

- New RuleTester suite covering fragile-in-action (invalid), fragile-in-assertion (valid), `getByRole` with/without `{ name }`, stable locators, `getByLabel`, stored-variable chains, and `filePattern` scoping.
- Registration assertions added to `tests/lib/index.test.js` (auto-registered, in `configs.all`, absent from `recommended`/`strict`).
- Full suite: 1602 tests pass; `eslint .` clean.

## Files

- `lib/rules/no-fragile-locators.js` (new)
- `docs/rules/no-fragile-locators.md` (new)
- `tests/lib/rules/no-fragile-locators.test.js` (new)
- `tests/lib/index.test.js` (registration assertions)

Closes #47

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional lint rule and tests only; no runtime or security-sensitive paths. Adoption is explicit via `configs.all` or manual enablement.
> 
> **Overview**
> Adds opt-in ESLint rule **`test-flakiness/no-fragile-locators`** for Playwright E2E specs (default `*.spec.ts`). It reports when **fragile** locators—`getByText` and, by default, `getByRole` without `{ name }`—are used as the receiver of **action/wait** methods (`click`, `fill`, `waitFor`, etc.), while leaving the same locators in **`expect(...)`** alone.
> 
> Implementation walks locator chains (refinements, `frameLocator`/`locator`, stored variables, reassignments, aliases) to find the underlying factory, with configurable `fragile`, `stable`, `actionMethods`, `flagRoleWithoutName`, and `filePattern`. The rule is **auto-registered**, enabled only in **`configs.all`**, and **not** in `recommended` or `strict`. Docs and RuleTester/index registration tests are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82486b6e3a6139f2f54c584c983b4dc0fea95eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->