### PR TITLE
feat(rule): add no-overbudget-timeout ESLint rule (#48)

### DIFF
--- a/docs/rules/no-overbudget-timeout.md
+++ b/docs/rules/no-overbudget-timeout.md
@@ -1,0 +1,181 @@
+# no-overbudget-timeout
+
+Disallow timeout options that exceed the per-category budget
+
+## Rule Details
+
+This rule helps prevent test flakiness by flagging `timeout` options whose resolved value exceeds
+a per-category budget. Instead of a single global cap, it enforces separate budgets for
+**assertions** (calls rooted in `expect(...)`) and **interactions** (everything else). A timeout
+that drifts above the budget is usually a symptom of an underlying flaky wait or race condition;
+papering over it with a longer timeout hides the real problem and slows the whole suite down.
+
+The rule only runs inside test files. It inspects `timeout` properties passed as object options to
+call expressions and reports when:
+
+- An assertion timeout exceeds `maxTimeoutForAssertions`.
+- An interaction timeout exceeds `maxTimeoutForInteractions`.
+- A symbolic timeout tier cannot be resolved and `ignoreUnknownTiers` is `false`.
+
+Navigation operations (such as `page.goto`) are exempt by default because they legitimately need
+longer timeouts. Symbolic timeout values (e.g. `E2E_TIMEOUT_MS.unreliable`) are resolved through a
+configurable `namedTiers` map so that shared timeout constants can be budgeted just like literals.
+
+### Examples of **incorrect** code
+
+```javascript
+// Assertion timeout above the 5000ms assertion budget
+await expect(page.locator(".status")).toBeVisible({ timeout: 10000 });
+
+// Interaction timeout above the 5000ms interaction budget
+await page.click(".submit", { timeout: 8000 });
+
+// Symbolic tier resolved via namedTiers that exceeds the budget
+await page.fill("#email", "a@b.com", { timeout: E2E_TIMEOUT_MS.unreliable });
+```
+
+### Examples of **correct** code
+
+```javascript
+// Within the assertion budget
+await expect(page.locator(".status")).toBeVisible({ timeout: 5000 });
+
+// Within the interaction budget
+await page.click(".submit", { timeout: 3000 });
+
+// Navigation operations are exempt by default
+await page.goto("https://example.com", { timeout: 30000 });
+
+// A symbolic tier that resolves under the budget
+await page.fill("#email", "a@b.com", { timeout: E2E_TIMEOUT_MS.reliable });
+```
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+### `maxTimeoutForAssertions`
+
+- Type: `number`
+- Default: `5000`
+
+The maximum timeout (in milliseconds) allowed for assertion calls rooted in `expect(...)`.
+
+```json
+{
+  "rules": {
+    "test-flakiness/no-overbudget-timeout": [
+      "error",
+      { "maxTimeoutForAssertions": 3000 }
+    ]
+  }
+}
+```
+
+### `maxTimeoutForInteractions`
+
+- Type: `number`
+- Default: `5000`
+
+The maximum timeout (in milliseconds) allowed for interaction calls that are not assertions.
+
+```json
+{
+  "rules": {
+    "test-flakiness/no-overbudget-timeout": [
+      "error",
+      { "maxTimeoutForInteractions": 4000 }
+    ]
+  }
+}
+```
+
+### `allowHighTimeoutFor`
+
+- Type: `string[]`
+- Default: `["page.goto", "page.reload", "page.waitForNavigation"]`
+
+A list of dotted callee names that are exempt from the budget. Navigation operations are included
+by default because they legitimately require longer timeouts. Provide your own list to override the
+defaults.
+
+```json
+{
+  "rules": {
+    "test-flakiness/no-overbudget-timeout": [
+      "error",
+      {
+        "allowHighTimeoutFor": [
+          "page.goto",
+          "page.waitForNavigation",
+          "api.poll"
+        ]
+      }
+    ]
+  }
+}
+```
+
+### `namedTiers`
+
+- Type: `object` (string keys mapping to `number` values)
+- Default: `{}`
+
+Maps symbolic timeout names to their numeric millisecond values so the rule can budget timeouts
+that are expressed as constants instead of literals. The key is the dotted source-text name of the
+expression (for example `E2E_TIMEOUT_MS.unreliable`).
+
+```json
+{
+  "rules": {
+    "test-flakiness/no-overbudget-timeout": [
+      "error",
+      {
+        "namedTiers": {
+          "E2E_TIMEOUT_MS.reliable": 3000,
+          "E2E_TIMEOUT_MS.unreliable": 15000
+        }
+      }
+    ]
+  }
+}
+```
+
+### `ignoreUnknownTiers`
+
+- Type: `boolean`
+- Default: `true`
+
+When `true` (the default), a symbolic timeout that cannot be resolved through `namedTiers` is
+silently ignored. Set it to `false` to require every symbolic tier to be declared in `namedTiers`;
+unresolvable tiers are then reported so timeouts cannot bypass the budget.
+
+```json
+{
+  "rules": {
+    "test-flakiness/no-overbudget-timeout": [
+      "error",
+      { "ignoreUnknownTiers": false }
+    ]
+  }
+}
+```
+
+## When Not To Use It
+
+This rule may not be suitable if:
+
+- Your suite relies on long, intentional timeouts that cannot be expressed through
+  `allowHighTimeoutFor` or `namedTiers`.
+- You are testing timeout behavior itself.
+- You prefer a single global timeout cap rather than separate assertion and interaction budgets.
+
+## Related Rules
+
+- [no-hard-coded-timeout](./no-hard-coded-timeout.md)
+- [no-unconditional-wait](./no-unconditional-wait.md)
+
+## Further Reading
+
+- [Playwright - Timeouts](https://playwright.dev/docs/test-timeouts)
+- [Testing Library - waitFor](https://testing-library.com/docs/dom-testing-library/api-async/#waitfor)

--- a/lib/configs/strict.js
+++ b/lib/configs/strict.js
@@ -27,6 +27,7 @@ module.exports = {
     'test-flakiness/no-index-queries': 'error',
     'test-flakiness/no-focus-check': 'error',
     'test-flakiness/no-hard-coded-timeout': ['error', { maxTimeout: 500, allowInSetup: false }],
+    'test-flakiness/no-overbudget-timeout': 'error',
 
     // Low - Opinionated rules for maximum safety
     'test-flakiness/no-database-operations': 'error',

--- a/lib/rules/no-overbudget-timeout.js
+++ b/lib/rules/no-overbudget-timeout.js
@@ -1,0 +1,219 @@
+/**
+ * @fileoverview Rule to flag timeout options whose resolved value exceeds a
+ * per-category budget (assertions vs interactions), while exempting navigation
+ * operations and resolving symbolic tier constants via a configurable map.
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const { isTestFile, getFilename } = require('../utils/helpers');
+
+const DEFAULT_ALLOW_HIGH_TIMEOUT_FOR = [
+  'page.goto',
+  'page.reload',
+  'page.waitForNavigation'
+];
+
+/**
+ * Merge user options over documented defaults.
+ * @param {Object} raw - context.options[0]
+ * @returns {{maxTimeoutForAssertions:number, maxTimeoutForInteractions:number, allowHighTimeoutFor:string[], namedTiers:Object, ignoreUnknownTiers:boolean}}
+ */
+function resolveOptions(raw) {
+  const options = raw || {};
+  return {
+    maxTimeoutForAssertions:
+      typeof options.maxTimeoutForAssertions === 'number'
+        ? options.maxTimeoutForAssertions
+        : 5000,
+    maxTimeoutForInteractions:
+      typeof options.maxTimeoutForInteractions === 'number'
+        ? options.maxTimeoutForInteractions
+        : 5000,
+    allowHighTimeoutFor: Array.isArray(options.allowHighTimeoutFor)
+      ? options.allowHighTimeoutFor
+      : DEFAULT_ALLOW_HIGH_TIMEOUT_FOR,
+    namedTiers:
+      options.namedTiers && typeof options.namedTiers === 'object'
+        ? options.namedTiers
+        : {},
+    ignoreUnknownTiers:
+      typeof options.ignoreUnknownTiers === 'boolean'
+        ? options.ignoreUnknownTiers
+        : true
+  };
+}
+
+/**
+ * Build the dotted source-text name of a MemberExpression/Identifier chain
+ * (e.g. `E2E_TIMEOUT_MS.unreliable`, `page.goto`). Returns null if the chain
+ * contains computed/non-identifier parts.
+ * @param {Object} node - AST node
+ * @returns {string|null}
+ */
+function dottedName(node) {
+  if (!node) return null;
+  if (node.type === 'Identifier') return node.name;
+  if (node.type === 'MemberExpression' && !node.computed) {
+    const object = dottedName(node.object);
+    const property =
+      node.property && node.property.type === 'Identifier'
+        ? node.property.name
+        : null;
+    if (object === null || property === null) return null;
+    return `${object}.${property}`;
+  }
+  return null;
+}
+
+/**
+ * Resolve a timeout option value node to a number.
+ * @param {Object} node - the Property value node
+ * @param {Object} opts - resolved options
+ * @returns {{value:(number|null), tierName:(string|null), resolved:boolean}}
+ */
+function resolveTimeout(node, opts) {
+  if (node && node.type === 'Literal' && typeof node.value === 'number') {
+    return { value: node.value, tierName: null, resolved: true };
+  }
+  const tierName = dottedName(node);
+  if (tierName !== null && Object.prototype.hasOwnProperty.call(opts.namedTiers, tierName)) {
+    return { value: opts.namedTiers[tierName], tierName, resolved: true };
+  }
+  return { value: null, tierName, resolved: false };
+}
+
+/**
+ * Find the `timeout` Property inside an ObjectExpression argument.
+ * @param {Object} node - CallExpression
+ * @returns {Object|null}
+ */
+function findTimeoutProperty(node) {
+  for (const arg of node.arguments) {
+    if (!arg || arg.type !== 'ObjectExpression') continue;
+    for (const prop of arg.properties) {
+      if (
+        prop.type === 'Property' &&
+        !prop.computed &&
+        ((prop.key.type === 'Identifier' && prop.key.name === 'timeout') ||
+          (prop.key.type === 'Literal' && prop.key.value === 'timeout'))
+      ) {
+        return prop;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Determine whether a CallExpression's chain roots in `expect(...)`.
+ * @param {Object} callee - the CallExpression's callee
+ * @returns {boolean}
+ */
+function isExpectRooted(callee) {
+  let current = callee;
+  while (current && current.type === 'MemberExpression') {
+    current = current.object;
+  }
+  return (
+    current &&
+    current.type === 'CallExpression' &&
+    current.callee &&
+    current.callee.type === 'Identifier' &&
+    current.callee.name === 'expect'
+  );
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow timeout options that exceed the per-category budget',
+      category: 'Best Practices',
+      recommended: false,
+      url: 'https://github.com/tigredonorte/eslint-plugin-test-flakiness/blob/main/docs/rules/no-overbudget-timeout.md'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          maxTimeoutForAssertions: { type: 'number', default: 5000 },
+          maxTimeoutForInteractions: { type: 'number', default: 5000 },
+          allowHighTimeoutFor: {
+            type: 'array',
+            items: { type: 'string' },
+            default: DEFAULT_ALLOW_HIGH_TIMEOUT_FOR
+          },
+          namedTiers: {
+            type: 'object',
+            additionalProperties: { type: 'number' },
+            default: {}
+          },
+          ignoreUnknownTiers: { type: 'boolean', default: true }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      overbudgetAssertion:
+        'Timeout {{value}}ms exceeds the {{max}}ms budget for assertions. Tighten the tier or fix the underlying wait/race.',
+      overbudgetInteraction:
+        'Timeout {{value}}ms exceeds the {{max}}ms budget for interactions. Tighten the tier or fix the underlying wait/race.',
+      unresolvableTier:
+        'Unresolvable timeout tier \'{{tier}}\'. Add it to `namedTiers` or set `ignoreUnknownTiers: true`.'
+    }
+  },
+
+  create(context) {
+    const opts = resolveOptions(context.options[0]);
+
+    if (!isTestFile(getFilename(context))) {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        const timeoutProp = findTimeoutProperty(node);
+        if (!timeoutProp) return;
+
+        // allowHighTimeoutFor exemption (callee dotted-name).
+        const calleeName = dottedName(node.callee);
+        if (calleeName !== null && opts.allowHighTimeoutFor.includes(calleeName)) {
+          return;
+        }
+
+        const isAssertion = isExpectRooted(node.callee);
+        const { value, tierName, resolved } = resolveTimeout(
+          timeoutProp.value,
+          opts
+        );
+
+        if (!resolved) {
+          if (!opts.ignoreUnknownTiers && tierName !== null) {
+            context.report({
+              node: timeoutProp.value,
+              messageId: 'unresolvableTier',
+              data: { tier: tierName }
+            });
+          }
+          return;
+        }
+
+        const max = isAssertion
+          ? opts.maxTimeoutForAssertions
+          : opts.maxTimeoutForInteractions;
+
+        if (value > max) {
+          context.report({
+            node: timeoutProp.value,
+            messageId: isAssertion
+              ? 'overbudgetAssertion'
+              : 'overbudgetInteraction',
+            data: { value, max }
+          });
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/no-overbudget-timeout.test.js
+++ b/tests/lib/rules/no-overbudget-timeout.test.js
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview Tests for no-overbudget-timeout rule
+ * @author eslint-plugin-test-flakiness
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/no-overbudget-timeout');
+const { getRuleTester } = require('../../../lib/utils/test-helpers');
+
+const ruleTester = getRuleTester();
+
+const FILENAME = 'checkout.spec.js';
+
+ruleTester.run('no-overbudget-timeout', rule, {
+  valid: [
+    // Should not trigger on non-test files
+    {
+      code: 'await expect(btn).toBeVisible({ timeout: 15000 })',
+      filename: 'app.js'
+    },
+    // AC2: Numeric timeout under the assertion threshold is allowed
+    {
+      code: 'await expect(btn).toBeVisible({ timeout: 2000 })',
+      filename: FILENAME,
+      options: [{ maxTimeoutForAssertions: 5000 }]
+    },
+    // AC4: Symbolic GOOD tier within budget stays silent
+    {
+      code: 'await expect(btn).toBeVisible({ timeout: E2E_TIMEOUT_MS.long })',
+      filename: FILENAME,
+      options: [
+        {
+          maxTimeoutForAssertions: 5000,
+          namedTiers: { 'E2E_TIMEOUT_MS.long': 2000 }
+        }
+      ]
+    },
+    // AC5: Navigation operation in allowHighTimeoutFor is exempt
+    {
+      code: 'await page.goto(\'/app\', { timeout: E2E_TIMEOUT_MS.unreliable, waitUntil: \'domcontentloaded\' })',
+      filename: FILENAME,
+      options: [
+        {
+          maxTimeoutForInteractions: 5000,
+          allowHighTimeoutFor: ['page.goto'],
+          namedTiers: { 'E2E_TIMEOUT_MS.unreliable': 15000 }
+        }
+      ]
+    },
+    // AC7: Unknown symbolic tier is skipped when ignoreUnknownTiers is true
+    {
+      code: 'await expect(btn).toBeVisible({ timeout: SOME_UNKNOWN_TIER })',
+      filename: FILENAME,
+      options: [{ ignoreUnknownTiers: true, namedTiers: {} }]
+    }
+  ],
+  invalid: [
+    // AC1: Numeric timeout over the assertion threshold is reported
+    {
+      code: 'await expect(btn).toBeVisible({ timeout: 15000 })',
+      filename: FILENAME,
+      options: [{ maxTimeoutForAssertions: 5000 }],
+      errors: [{ messageId: 'overbudgetAssertion' }]
+    },
+    // AC3: Symbolic tier resolved via namedTiers, over budget
+    {
+      code: 'await expect(btn).toBeVisible({ timeout: E2E_TIMEOUT_MS.unreliable })',
+      filename: FILENAME,
+      options: [
+        {
+          maxTimeoutForAssertions: 5000,
+          namedTiers: { 'E2E_TIMEOUT_MS.unreliable': 15000 }
+        }
+      ],
+      errors: [{ messageId: 'overbudgetAssertion' }]
+    },
+    // AC6: Custom waitForApiResponse helper over budget reported as interaction
+    {
+      code: 'await waitForApiResponse(page, { urlPattern: \'save\', timeout: E2E_TIMEOUT_MS.unreliable })',
+      filename: FILENAME,
+      options: [
+        {
+          maxTimeoutForInteractions: 5000,
+          namedTiers: { 'E2E_TIMEOUT_MS.unreliable': 15000 }
+        }
+      ],
+      errors: [{ messageId: 'overbudgetInteraction' }]
+    },
+    // AC8: Unknown symbolic tier reported when ignoreUnknownTiers is false
+    {
+      code: 'await expect(btn).toBeVisible({ timeout: SOME_UNKNOWN_TIER })',
+      filename: FILENAME,
+      options: [{ ignoreUnknownTiers: false, namedTiers: {} }],
+      errors: [{ messageId: 'unresolvableTier' }]
+    }
+  ]
+});
+
+describe('no-overbudget-timeout meta', () => {
+  it('declares a problem-type rule with a docs url', () => {
+    expect(rule.meta.type).toBe('problem');
+    expect(rule.meta.docs.url).toMatch(/no-overbudget-timeout/);
+  });
+
+  it('locks the schema with additionalProperties: false and all five options', () => {
+    const schema = rule.meta.schema[0];
+    expect(schema.additionalProperties).toBe(false);
+    expect(Object.keys(schema.properties)).toEqual(
+      expect.arrayContaining([
+        'maxTimeoutForAssertions',
+        'maxTimeoutForInteractions',
+        'allowHighTimeoutFor',
+        'namedTiers',
+        'ignoreUnknownTiers'
+      ])
+    );
+  });
+
+  it('exposes the three exact message ids and texts', () => {
+    expect(rule.meta.messages.overbudgetAssertion).toBe(
+      'Timeout {{value}}ms exceeds the {{max}}ms budget for assertions. Tighten the tier or fix the underlying wait/race.'
+    );
+    expect(rule.meta.messages.overbudgetInteraction).toBe(
+      'Timeout {{value}}ms exceeds the {{max}}ms budget for interactions. Tighten the tier or fix the underlying wait/race.'
+    );
+    expect(rule.meta.messages.unresolvableTier).toBe(
+      'Unresolvable timeout tier \'{{tier}}\'. Add it to `namedTiers` or set `ignoreUnknownTiers: true`.'
+    );
+  });
+});


### PR DESCRIPTION
## Existing Behavior

- The plugin had no mechanism to enforce per-category timeout budgets; any numeric or symbolic timeout could be passed without restriction.
- Assertions (rooted in `expect(...)`) and interactions (page actions, helpers) were treated identically — no differentiation existed for budget enforcement.
- Navigation operations such as `page.goto` had no exemption mechanism, making it impossible to allow higher timeouts only where legitimate.
- Symbolic timeout constants (e.g. `E2E_TIMEOUT_MS.unreliable`) could not be budgeted because the plugin had no way to resolve them to a numeric value.

## Intended New Behavior

- The new `no-overbudget-timeout` rule flags `timeout` options whose resolved value exceeds configurable per-category budgets: `maxTimeoutForAssertions` (default 5000ms) for `expect`-rooted calls and `maxTimeoutForInteractions` (default 5000ms) for everything else.
- Symbolic timeout constants are resolved through a configurable `namedTiers` map (e.g. `{ "E2E_TIMEOUT_MS.unreliable": 15000 }`), enabling budget enforcement over shared project-wide timeout constants.
- Navigation operations (`page.goto`, `page.reload`, `page.waitForNavigation`) are exempt by default via `allowHighTimeoutFor`; callers can override the list with their own set.
- Unknown symbolic tiers are silently skipped by default (`ignoreUnknownTiers: true`); setting it to `false` forces every tier to be declared in `namedTiers`, closing the bypass gap.
- The rule is registered in `lib/configs/strict.js` with default settings; `recommended.js` is intentionally unchanged because this rule encodes a project-specific timeout band.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Unit tests (12 passing, AC1–AC8):**

```
pnpm test tests/lib/rules/no-overbudget-timeout.test.js
```

**Manual ESLint smoke test:**

1. Add the rule to your local ESLint config:
   ```json
   {
     "rules": {
       "test-flakiness/no-overbudget-timeout": ["error", {
         "maxTimeoutForAssertions": 5000,
         "maxTimeoutForInteractions": 5000,
         "namedTiers": { "E2E_TIMEOUT_MS.unreliable": 15000 }
       }]
     }
   }
   ```
2. Create a test file `checkout.spec.js` containing:
   ```js
   await expect(btn).toBeVisible({ timeout: 15000 });           // should error (overbudgetAssertion)
   await page.click('.submit', { timeout: 8000 });              // should error (overbudgetInteraction)
   await page.goto('/app', { timeout: 30000 });                 // should pass (navigation exempt)
   await expect(btn).toBeVisible({ timeout: E2E_TIMEOUT_MS.unreliable }); // should error via namedTiers
   ```
3. Run `eslint checkout.spec.js` and confirm errors are reported only on lines 1, 2, and 4.

### Test Results

```
PASS tests/lib/rules/no-overbudget-timeout.test.js
  no-overbudget-timeout
    valid
      ✓ await expect(btn).toBeVisible({ timeout: 15000 }) (non-test file)
      ✓ await expect(btn).toBeVisible({ timeout: 2000 }) (AC2)
      ✓ await expect(btn).toBeVisible({ timeout: E2E_TIMEOUT_MS.long }) (AC4)
      ✓ await page.goto('/app', ...) navigation exempt (AC5)
      ✓ await expect(btn).toBeVisible({ timeout: SOME_UNKNOWN_TIER }) (AC7)
    invalid
      ✓ await expect(btn).toBeVisible({ timeout: 15000 }) (AC1)
      ✓ await expect(btn).toBeVisible({ timeout: E2E_TIMEOUT_MS.unreliable }) (AC3)
      ✓ await waitForApiResponse(page, { ..., timeout: E2E_TIMEOUT_MS.unreliable }) (AC6)
      ✓ await expect(btn).toBeVisible({ timeout: SOME_UNKNOWN_TIER }) (AC8)
  no-overbudget-timeout meta
      ✓ declares a problem-type rule with a docs url
      ✓ locks the schema with additionalProperties: false and all five options
      ✓ exposes the three exact message ids and texts

Tests: 12 passed, 12 total
```

Closes #48

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an opt-in lint rule and strict-config entry only; no runtime or API behavior changes outside ESLint analysis.
> 
> **Overview**
> Adds **`test-flakiness/no-overbudget-timeout`**, which flags `timeout` options in test files when the resolved value exceeds separate budgets for **`expect(...)` assertions** vs other **interactions** (defaults 5000ms each).
> 
> The rule resolves numeric literals and symbolic constants via a configurable **`namedTiers`** map, skips **`allowHighTimeoutFor`** callees (default navigation helpers), and can optionally error on unknown tiers when **`ignoreUnknownTiers`** is false. Documentation, rule tests, and enabling the rule in **`strict`** config are included; **`recommended`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50dab41ab30c580988c0430282c14d95aa02052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->